### PR TITLE
fix(api): persist workflow and assistant thread state

### DIFF
--- a/apps/api/alembic/versions/0004_workflow_todos.py
+++ b/apps/api/alembic/versions/0004_workflow_todos.py
@@ -1,0 +1,59 @@
+"""workflow todos
+
+Revision ID: 0004_workflow_todos
+Revises: 0003_whm_servers
+Create Date: 2026-03-16 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0004_workflow_todos"
+down_revision: Union[str, None] = "0003_whm_servers"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflow_todos",
+        sa.Column("thread_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("priority", sa.String(length=20), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["thread_id"], ["threads.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("thread_id", "position"),
+        sa.CheckConstraint(
+            "status IN ('pending', 'in_progress', 'completed', 'cancelled')",
+            name="ck_workflow_todos_status",
+        ),
+        sa.CheckConstraint(
+            "priority IN ('high', 'medium', 'low')",
+            name="ck_workflow_todos_priority",
+        ),
+    )
+    op.create_index(
+        "ix_workflow_todos_thread_id", "workflow_todos", ["thread_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workflow_todos_thread_id", table_name="workflow_todos")
+    op.drop_table("workflow_todos")

--- a/apps/api/src/noa_api/api/assistant/assistant_action_operations.py
+++ b/apps/api/src/noa_api/api/assistant/assistant_action_operations.py
@@ -322,7 +322,11 @@ async def execute_approved_tool_run(
     try:
         validate_tool_arguments(tool=tool, args=approved_request.args)
         result = await _execute_tool(
-            tool=tool, args=approved_request.args, session=session
+            tool=tool,
+            args=approved_request.args,
+            session=session,
+            thread_id=thread_id,
+            requested_by_user_id=owner_user_id,
         )
         completed = await action_tool_run_service.complete_tool_run(
             tool_run_id=started_tool_run.id,
@@ -419,9 +423,20 @@ async def _execute_tool(
     tool: Any,
     args: dict[str, object],
     session: AsyncSession | None,
+    thread_id: UUID,
+    requested_by_user_id: UUID,
 ) -> dict[str, object]:
-    if session is not None and "session" in signature(tool.execute).parameters:
-        return await tool.execute(session=session, **args)
+    execute_parameters = signature(tool.execute).parameters
+    execute_kwargs: dict[str, object] = dict(args)
+    if session is not None and "session" in execute_parameters:
+        execute_kwargs["session"] = session
+    if "thread_id" in execute_parameters:
+        execute_kwargs["thread_id"] = thread_id
+    if "requested_by_user_id" in execute_parameters:
+        execute_kwargs["requested_by_user_id"] = requested_by_user_id
+
+    if execute_kwargs is not args:
+        return await tool.execute(**execute_kwargs)
     return await tool.execute(**args)
 
 

--- a/apps/api/src/noa_api/api/assistant/assistant_operations.py
+++ b/apps/api/src/noa_api/api/assistant/assistant_operations.py
@@ -158,6 +158,18 @@ def _safe_report(telemetry: TelemetryRecorder | None, event: TelemetryEvent) -> 
         )
 
 
+def _apply_canonical_state(
+    state: dict[str, object],
+    canonical_state: dict[str, object],
+    *,
+    is_running: bool,
+) -> None:
+    state["messages"] = coerce_messages(canonical_state.get("messages"))
+    state["workflow"] = canonical_state.get("workflow") or []
+    state["pendingApprovals"] = canonical_state.get("pendingApprovals") or []
+    state["isRunning"] = is_running
+
+
 def _record_assistant_failure_telemetry(
     telemetry: TelemetryRecorder | None,
     *,
@@ -264,10 +276,15 @@ async def run_agent_phase(
         allowed_tools.add("update_workflow_todo")
 
         base_messages = coerce_messages(canonical_state.get("messages"))
+        controller.state["workflow"] = canonical_state.get("workflow") or []
+        controller.state["pendingApprovals"] = (
+            canonical_state.get("pendingApprovals") or []
+        )
         controller.state["messages"] = [
             *base_messages,
             make_streaming_placeholder(""),
         ]
+        controller.state["isRunning"] = True
         await flush_controller_state(controller)
 
         streamed_text = ""
@@ -379,7 +396,7 @@ async def run_agent_phase(
                 owner_user_id=current_user.user_id,
                 thread_id=payload.thread_id,
             )
-            controller.state["messages"] = coerce_messages(failed_state.get("messages"))
+            _apply_canonical_state(controller.state, failed_state, is_running=False)
 
             if not persisted_error_message:
                 controller.state["messages"] = append_fallback_error_message(
@@ -402,8 +419,7 @@ async def run_agent_phase(
             owner_user_id=current_user.user_id,
             thread_id=payload.thread_id,
         )
-        controller.state["messages"] = coerce_messages(updated_state.get("messages"))
-        controller.state["isRunning"] = False
+        _apply_canonical_state(controller.state, updated_state, is_running=False)
     except asyncio.CancelledError:
         raise
     except Exception as exc:

--- a/apps/api/src/noa_api/api/assistant/assistant_repository.py
+++ b/apps/api/src/noa_api/api/assistant/assistant_repository.py
@@ -6,7 +6,8 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from noa_api.storage.postgres.models import AuditLog, Message, Thread
+from noa_api.storage.postgres.lifecycle import ActionRequestStatus
+from noa_api.storage.postgres.models import ActionRequest, AuditLog, Message, Thread
 
 
 class SQLAssistantRepository:
@@ -28,6 +29,19 @@ class SQLAssistantRepository:
             select(Message)
             .where(Message.thread_id == thread_id)
             .order_by(Message.created_at.asc(), Message.id.asc())
+        )
+        return list(result.scalars().all())
+
+    async def get_pending_action_requests(
+        self, *, thread_id: UUID
+    ) -> list[ActionRequest]:
+        result = await self._session.execute(
+            select(ActionRequest)
+            .where(
+                ActionRequest.thread_id == thread_id,
+                ActionRequest.status == ActionRequestStatus.PENDING,
+            )
+            .order_by(ActionRequest.created_at.asc(), ActionRequest.id.asc())
         )
         return list(result.scalars().all())
 

--- a/apps/api/src/noa_api/api/assistant/assistant_tool_result_operations.py
+++ b/apps/api/src/noa_api/api/assistant/assistant_tool_result_operations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any, Protocol
 from uuid import UUID
 
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class AssistantMessageAuditRepositoryProtocol(Protocol):
-    async def list_messages(self, *, thread_id: UUID) -> list[object]: ...
+    async def list_messages(self, *, thread_id: UUID) -> Sequence[object]: ...
 
     async def create_message(
         self, *, thread_id: UUID, role: str, parts: list[dict[str, object]]

--- a/apps/api/src/noa_api/api/routes/assistant.py
+++ b/apps/api/src/noa_api/api/routes/assistant.py
@@ -34,6 +34,7 @@ from noa_api.api.assistant.assistant_errors import (
 )
 from noa_api.api.assistant.assistant_operations import (
     _record_assistant_failure_telemetry,
+    _apply_canonical_state,
     prepare_assistant_transport,
     run_agent_phase,
 )
@@ -57,7 +58,12 @@ from noa_api.storage.postgres.action_tool_runs import (
     ActionToolRunService,
     SQLActionToolRunRepository,
 )
+from noa_api.storage.postgres.models import ActionRequest
 from noa_api.storage.postgres.client import get_session_factory
+from noa_api.storage.postgres.workflow_todos import (
+    SQLWorkflowTodoRepository,
+    WorkflowTodoService,
+)
 
 router = APIRouter(tags=["assistant"])
 
@@ -80,25 +86,58 @@ class AssistantThreadStateMessage(BaseModel):
     parts: list[dict[str, Any]]
 
 
+class AssistantWorkflowTodo(BaseModel):
+    content: str
+    status: str
+    priority: str
+
+
+class AssistantPendingApproval(BaseModel):
+    action_request_id: str = Field(alias="actionRequestId")
+    tool_name: str = Field(alias="toolName")
+    risk: str
+    arguments: dict[str, Any]
+    status: str
+
+    model_config = {"populate_by_name": True}
+
+
 class AssistantThreadStateResponse(BaseModel):
     messages: list[AssistantThreadStateMessage]
+    workflow: list[AssistantWorkflowTodo] = Field(default_factory=list)
+    pending_approvals: list[AssistantPendingApproval] = Field(
+        default_factory=list,
+        alias="pendingApprovals",
+    )
     is_running: bool = Field(alias="isRunning")
 
     model_config = {"populate_by_name": True}
 
 
+def _serialize_pending_approval(request: ActionRequest) -> dict[str, object]:
+    return {
+        "actionRequestId": str(request.id),
+        "toolName": request.tool_name,
+        "risk": request.risk.value,
+        "arguments": request.args,
+        "status": request.status.value,
+    }
+
+
 class AssistantService:
     def __init__(
         self,
-        repository: SQLAssistantRepository,
-        runner: AgentRunner,
+        repository: Any,
+        runner: Any,
         *,
         action_tool_run_service: ActionToolRunService,
+        workflow_todo_service: WorkflowTodoService | None = None,
         session: AsyncSession,
     ) -> None:
         self._repository = repository
         self._runner = runner
         self._action_tool_run_service = action_tool_run_service
+        self._workflow_todo_service = workflow_todo_service
         self._session = session
 
     async def load_state(
@@ -115,6 +154,14 @@ class AssistantService:
             )
 
         messages = await self._repository.list_messages(thread_id=thread_id)
+        workflow = (
+            await self._workflow_todo_service.list_workflow(thread_id=thread_id)
+            if self._workflow_todo_service is not None
+            else []
+        )
+        pending_action_requests = await self._repository.get_pending_action_requests(
+            thread_id=thread_id
+        )
         return {
             "messages": [
                 {
@@ -123,6 +170,11 @@ class AssistantService:
                     "parts": message.content,
                 }
                 for message in messages
+            ],
+            "workflow": workflow,
+            "pendingApprovals": [
+                _serialize_pending_approval(request)
+                for request in pending_action_requests
             ],
             "isRunning": False,
         }
@@ -270,17 +322,19 @@ class AssistantService:
 
 async def get_assistant_service() -> AsyncGenerator[AssistantService, None]:
     async with get_session_factory()() as session:
+        action_tool_run_service = ActionToolRunService(
+            repository=SQLActionToolRunRepository(session)
+        )
         service = AssistantService(
             SQLAssistantRepository(session),
             AgentRunner(
                 llm_client=create_default_llm_client(),
-                action_tool_run_service=ActionToolRunService(
-                    repository=SQLActionToolRunRepository(session)
-                ),
+                action_tool_run_service=action_tool_run_service,
                 session=session,
             ),
-            action_tool_run_service=ActionToolRunService(
-                repository=SQLActionToolRunRepository(session)
+            action_tool_run_service=action_tool_run_service,
+            workflow_todo_service=WorkflowTodoService(
+                repository=SQLWorkflowTodoRepository(session)
             ),
             session=session,
         )
@@ -430,8 +484,7 @@ async def assistant_transport(
             if controller.state is None:
                 controller.state = {}
 
-            controller.state["messages"] = canonical_state["messages"]
-            controller.state["isRunning"] = True
+            _apply_canonical_state(controller.state, canonical_state, is_running=True)
 
             if should_run_agent(payload.commands):
                 await run_agent_phase(
@@ -446,7 +499,7 @@ async def assistant_transport(
                 )
                 return
 
-            controller.state["isRunning"] = False
+            _apply_canonical_state(controller.state, canonical_state, is_running=False)
 
     stream = create_run(run_callback, state=payload.state)
     return AssistantTransportResponse(stream)

--- a/apps/api/src/noa_api/core/agent/runner.py
+++ b/apps/api/src/noa_api/core/agent/runner.py
@@ -560,7 +560,12 @@ class AgentRunner:
 
         try:
             validate_tool_arguments(tool=tool, args=args)
-            result = await self._execute_tool(tool=tool, args=args)
+            result = await self._execute_tool(
+                tool=tool,
+                args=args,
+                thread_id=thread_id,
+                requested_by_user_id=requested_by_user_id,
+            )
             safe_result = json_safe(result)
             result_payload = (
                 safe_result if isinstance(safe_result, dict) else {"value": safe_result}
@@ -636,13 +641,24 @@ class AgentRunner:
         return None
 
     async def _execute_tool(
-        self, *, tool: ToolDefinition, args: dict[str, object]
+        self,
+        *,
+        tool: ToolDefinition,
+        args: dict[str, object],
+        thread_id: UUID,
+        requested_by_user_id: UUID,
     ) -> dict[str, object]:
-        if (
-            self._session is not None
-            and "session" in signature(tool.execute).parameters
-        ):
-            return await tool.execute(session=self._session, **args)
+        execute_parameters = signature(tool.execute).parameters
+        execute_kwargs: dict[str, object] = dict(args)
+        if self._session is not None and "session" in execute_parameters:
+            execute_kwargs["session"] = self._session
+        if "thread_id" in execute_parameters:
+            execute_kwargs["thread_id"] = thread_id
+        if "requested_by_user_id" in execute_parameters:
+            execute_kwargs["requested_by_user_id"] = requested_by_user_id
+
+        if execute_kwargs is not args:
+            return await tool.execute(**execute_kwargs)
         return await tool.execute(**args)
 
 

--- a/apps/api/src/noa_api/core/tools/workflow_todo.py
+++ b/apps/api/src/noa_api/core/tools/workflow_todo.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from noa_api.storage.postgres.workflow_todos import (
+    SQLWorkflowTodoRepository,
+    WorkflowTodoItem,
+    WorkflowTodoService,
+)
 
 
 _VALID_TODO_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
 _VALID_TODO_PRIORITIES = {"high", "medium", "low"}
 
 
-async def update_workflow_todo(*, todos: list[dict[str, Any]]) -> dict[str, Any]:
+async def _validate_workflow_todos(*, todos: list[dict[str, Any]]) -> dict[str, Any]:
+    validated_todos: list[WorkflowTodoItem] = []
     in_progress_count = 0
     for index, todo in enumerate(todos, start=1):
         content = todo.get("content")
@@ -42,6 +52,14 @@ async def update_workflow_todo(*, todos: list[dict[str, Any]]) -> dict[str, Any]
                 ),
             }
 
+        validated_todos.append(
+            {
+                "content": content,
+                "status": status,
+                "priority": priority,
+            }
+        )
+
     if in_progress_count > 1:
         return {
             "ok": False,
@@ -49,4 +67,26 @@ async def update_workflow_todo(*, todos: list[dict[str, Any]]) -> dict[str, Any]
             "message": "Only one workflow TODO item can be in_progress at a time",
         }
 
-    return {"ok": True, "todos": todos}
+    return {"ok": True, "todos": validated_todos}
+
+
+async def update_workflow_todo(
+    *,
+    todos: list[dict[str, Any]],
+    session: AsyncSession | None = None,
+    thread_id: UUID | None = None,
+) -> dict[str, Any]:
+    result = await _validate_workflow_todos(todos=todos)
+    if not result.get("ok"):
+        return result
+
+    if session is not None and thread_id is not None:
+        workflow_todo_service = WorkflowTodoService(
+            repository=SQLWorkflowTodoRepository(session)
+        )
+        await workflow_todo_service.replace_workflow(
+            thread_id=thread_id,
+            todos=result["todos"],
+        )
+
+    return result

--- a/apps/api/src/noa_api/storage/postgres/models.py
+++ b/apps/api/src/noa_api/storage/postgres/models.py
@@ -164,6 +164,29 @@ class Message(Base):
     )
 
 
+class WorkflowTodo(Base):
+    __tablename__ = "workflow_todos"
+
+    thread_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("threads.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    position: Mapped[int] = mapped_column(primary_key=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    priority: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class ActionRequest(Base):
     __tablename__ = "action_requests"
 

--- a/apps/api/src/noa_api/storage/postgres/workflow_todos.py
+++ b/apps/api/src/noa_api/storage/postgres/workflow_todos.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, Protocol, TypedDict
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from noa_api.storage.postgres.models import WorkflowTodo
+
+WorkflowTodoStatus = Literal["pending", "in_progress", "completed", "cancelled"]
+WorkflowTodoPriority = Literal["high", "medium", "low"]
+
+
+class WorkflowTodoItem(TypedDict):
+    content: str
+    status: WorkflowTodoStatus
+    priority: WorkflowTodoPriority
+
+
+class WorkflowTodoRepositoryProtocol(Protocol):
+    async def replace_workflow(
+        self, *, thread_id: UUID, todos: Sequence[WorkflowTodoItem]
+    ) -> None: ...
+
+    async def list_workflow(self, *, thread_id: UUID) -> list[WorkflowTodo]: ...
+
+    async def clear_workflow(self, *, thread_id: UUID) -> None: ...
+
+
+class SQLWorkflowTodoRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def replace_workflow(
+        self, *, thread_id: UUID, todos: Sequence[WorkflowTodoItem]
+    ) -> None:
+        await self.clear_workflow(thread_id=thread_id)
+        for position, todo in enumerate(todos):
+            self._session.add(
+                WorkflowTodo(
+                    thread_id=thread_id,
+                    position=position,
+                    content=todo["content"],
+                    status=todo["status"],
+                    priority=todo["priority"],
+                )
+            )
+        await self._session.flush()
+
+    async def list_workflow(self, *, thread_id: UUID) -> list[WorkflowTodo]:
+        result = await self._session.execute(
+            select(WorkflowTodo)
+            .where(WorkflowTodo.thread_id == thread_id)
+            .order_by(WorkflowTodo.position.asc())
+        )
+        return list(result.scalars().all())
+
+    async def clear_workflow(self, *, thread_id: UUID) -> None:
+        await self._session.execute(
+            delete(WorkflowTodo).where(WorkflowTodo.thread_id == thread_id)
+        )
+        await self._session.flush()
+
+
+class WorkflowTodoService:
+    def __init__(self, *, repository: WorkflowTodoRepositoryProtocol) -> None:
+        self._repository = repository
+
+    async def replace_workflow(
+        self, *, thread_id: UUID, todos: Sequence[WorkflowTodoItem]
+    ) -> list[WorkflowTodoItem]:
+        normalized: list[WorkflowTodoItem] = [
+            {
+                "content": todo["content"],
+                "status": todo["status"],
+                "priority": todo["priority"],
+            }
+            for todo in todos
+        ]
+        await self._repository.replace_workflow(thread_id=thread_id, todos=normalized)
+        return normalized
+
+    async def list_workflow(self, *, thread_id: UUID) -> list[WorkflowTodoItem]:
+        return [
+            {
+                "content": todo.content,
+                "status": todo.status,
+                "priority": todo.priority,
+            }
+            for todo in await self._repository.list_workflow(thread_id=thread_id)
+        ]
+
+    async def clear_workflow(self, *, thread_id: UUID) -> None:
+        await self._repository.clear_workflow(thread_id=thread_id)

--- a/apps/api/tests/test_assistant.py
+++ b/apps/api/tests/test_assistant.py
@@ -190,6 +190,8 @@ class _FakeAssistantService:
     owner_user_id: UUID
     thread_id: UUID
     messages: list[dict[str, object]] = field(default_factory=list)
+    workflow: list[dict[str, object]] = field(default_factory=list)
+    pending_approvals: list[dict[str, object]] = field(default_factory=list)
     runner_messages: list[AgentMessage] = field(default_factory=list)
     runner_text_deltas: list[str] = field(default_factory=list)
     seen_available_tools: set[str] = field(default_factory=set)
@@ -204,6 +206,8 @@ class _FakeAssistantService:
         assert thread_id == self.thread_id
         return {
             "messages": list(self.messages),
+            "workflow": list(self.workflow),
+            "pendingApprovals": list(self.pending_approvals),
             "isRunning": False,
         }
 
@@ -322,6 +326,10 @@ class _RouteAssistantRepository:
         _ = thread_id
         return []
 
+    async def get_pending_action_requests(self, *, thread_id: UUID):
+        _ = thread_id
+        return []
+
     async def create_message(self, **kwargs):
         raise AssertionError(f"create_message should not be called: {kwargs}")
 
@@ -375,7 +383,7 @@ def _build_real_service_app(*, owner_id: UUID, thread_id: UUID) -> FastAPI:
 
 
 def _build_app(
-    service: _FakeAssistantService,
+    service: Any,
     current_user: AuthorizationUser,
     authorization_service: _FakeAuthorizationService | None = None,
 ) -> FastAPI:
@@ -448,6 +456,126 @@ async def test_thread_state_route_hydrates_persisted_state() -> None:
     data = response.json()
     assert _state_contains_text(data, expected_text)
     assert data["isRunning"] is False
+
+
+async def test_thread_state_route_includes_workflow_and_pending_approvals() -> None:
+    owner_id = uuid4()
+    thread_id = uuid4()
+    service = _FakeAssistantService(
+        owner_user_id=owner_id,
+        thread_id=thread_id,
+        workflow=[
+            {"content": "Preflight", "status": "completed", "priority": "high"},
+            {
+                "content": "Request approval",
+                "status": "in_progress",
+                "priority": "high",
+            },
+        ],
+        pending_approvals=[
+            {
+                "actionRequestId": str(uuid4()),
+                "toolName": "set_demo_flag",
+                "risk": "CHANGE",
+                "arguments": {"key": "feature_x", "value": True},
+                "status": "PENDING",
+            }
+        ],
+    )
+    app = _build_app(
+        service,
+        AuthorizationUser(
+            user_id=owner_id,
+            email="owner@example.com",
+            display_name="Owner",
+            is_active=True,
+            roles=["member"],
+            tools=[],
+        ),
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/assistant/threads/{thread_id}/state")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["workflow"] == service.workflow
+    assert data["pendingApprovals"] == service.pending_approvals
+
+
+async def test_assistant_route_streams_canonical_workflow_and_pending_approvals() -> (
+    None
+):
+    owner_id = uuid4()
+    thread_id = uuid4()
+    service = _FakeAssistantService(
+        owner_user_id=owner_id,
+        thread_id=thread_id,
+        messages=[
+            {
+                "id": str(uuid4()),
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "From DB"}],
+            }
+        ],
+        workflow=[
+            {"content": "Preflight", "status": "completed", "priority": "high"},
+            {
+                "content": "Request approval",
+                "status": "in_progress",
+                "priority": "high",
+            },
+        ],
+        pending_approvals=[
+            {
+                "actionRequestId": str(uuid4()),
+                "toolName": "set_demo_flag",
+                "risk": "CHANGE",
+                "arguments": {"key": "feature_x", "value": True},
+                "status": "PENDING",
+            }
+        ],
+    )
+    app = _build_app(
+        service,
+        AuthorizationUser(
+            user_id=owner_id,
+            email="owner@example.com",
+            display_name="Owner",
+            is_active=True,
+            roles=["member"],
+            tools=[],
+        ),
+    )
+
+    payload = {
+        "state": {"messages": [], "isRunning": False},
+        "commands": [],
+        "threadId": str(thread_id),
+    }
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/assistant", json=payload)
+
+    assert response.status_code == 200
+
+    state: dict[str, object] = {}
+    for event in _iter_assistant_transport_events(response.text):
+        if event.get("type") != "update-state":
+            continue
+        operations = event.get("operations") or event.get("patches")
+        if isinstance(operations, list):
+            _apply_assistant_stream_patches(state, operations)
+            continue
+        event_state = event.get("state")
+        if isinstance(event_state, dict):
+            state.clear()
+            state.update(event_state)
+
+    assert state.get("workflow") == service.workflow
+    assert state.get("pendingApprovals") == service.pending_approvals
 
 
 async def test_assistant_route_returns_structured_http_error_when_thread_missing() -> (

--- a/apps/api/tests/test_assistant_operations.py
+++ b/apps/api/tests/test_assistant_operations.py
@@ -265,6 +265,40 @@ class _FakeAssistantServiceThatFailsStateRefresh:
         raise RuntimeError("refresh failed")
 
 
+@dataclass
+class _FakeAssistantServiceThatSucceedsAgentRun:
+    refreshed_state: dict[str, object]
+    seen_available_tools: set[str] = field(default_factory=set)
+
+    async def run_agent_turn(
+        self,
+        *,
+        owner_user_id: UUID,
+        owner_user_email: str | None,
+        thread_id: UUID,
+        available_tool_names: set[str],
+        on_text_delta: Any = None,
+    ) -> None:
+        _ = owner_user_id, owner_user_email, thread_id, on_text_delta
+        self.seen_available_tools = set(available_tool_names)
+
+    async def add_message(
+        self,
+        *,
+        owner_user_id: UUID,
+        thread_id: UUID,
+        role: str,
+        parts: list[dict[str, object]],
+    ) -> None:
+        _ = owner_user_id, thread_id, role, parts
+
+    async def load_state(
+        self, *, owner_user_id: UUID, thread_id: UUID
+    ) -> dict[str, object]:
+        _ = owner_user_id, thread_id
+        return self.refreshed_state
+
+
 async def test_prepare_assistant_transport_validates_commands_before_mutation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -370,6 +404,49 @@ async def test_run_agent_phase_persists_safe_error_message_on_failure() -> None:
     assert controller.state is not None
     assert controller.state["isRunning"] is False
     assert _state_contains_text(controller.state, error_text)
+
+
+async def test_run_agent_phase_refreshes_workflow_and_pending_approvals() -> None:
+    refreshed_state = {
+        "messages": [_message_with_text("Agent reply", role="assistant")],
+        "workflow": [
+            {"content": "Preflight", "status": "completed", "priority": "high"},
+            {
+                "content": "Request approval",
+                "status": "in_progress",
+                "priority": "high",
+            },
+        ],
+        "pendingApprovals": [
+            {
+                "actionRequestId": str(uuid4()),
+                "toolName": "set_demo_flag",
+                "risk": "CHANGE",
+                "arguments": {"key": "feature_x", "value": True},
+                "status": "PENDING",
+            }
+        ],
+        "isRunning": False,
+    }
+    controller = _FakeController(state={})
+    service = _FakeAssistantServiceThatSucceedsAgentRun(refreshed_state=refreshed_state)
+
+    await assistant_operations.run_agent_phase(
+        controller=controller,
+        payload=_payload_with_user_message(),
+        current_user=_active_user(),
+        assistant_service=service,
+        authorization_service=_FakeAuthorizationService(),
+        canonical_state={
+            "messages": [],
+            "workflow": [],
+            "pendingApprovals": [],
+            "isRunning": False,
+        },
+        command_types=["add-message"],
+    )
+
+    assert controller.state == refreshed_state
 
 
 async def test_run_agent_phase_emits_structured_agent_failure_log() -> None:

--- a/apps/api/tests/test_assistant_service.py
+++ b/apps/api/tests/test_assistant_service.py
@@ -95,6 +95,10 @@ class _FakeAssistantRepository:
         _ = thread_id
         return self.listed_messages
 
+    async def get_pending_action_requests(self, *, thread_id: UUID):
+        _ = thread_id
+        return []
+
     async def create_message(
         self, *, thread_id: UUID, role: str, parts: list[dict[str, object]]
     ):
@@ -119,6 +123,15 @@ class _FakeAssistantRepository:
                 "metadata": metadata,
             }
         )
+
+
+@dataclass
+class _FakeWorkflowTodoService:
+    todos: list[dict[str, str]] = field(default_factory=list)
+
+    async def list_workflow(self, *, thread_id: UUID):
+        _ = thread_id
+        return list(self.todos)
 
 
 @dataclass
@@ -304,6 +317,88 @@ async def test_record_tool_result_rejects_foreign_thread() -> None:
     assert repo.tool_runs[started.id].status == ToolRunStatus.STARTED
     assert assistant_repo.messages == []
     assert assistant_repo.audits == []
+
+
+async def test_assistant_service_load_state_includes_workflow_and_pending_approvals() -> (
+    None
+):
+    owner_id = uuid4()
+    thread_id = uuid4()
+    pending_request_id = uuid4()
+    assistant_repo = _FakeAssistantRepository(
+        listed_messages=[
+            SimpleNamespace(
+                id=uuid4(),
+                role="assistant",
+                content=[{"type": "text", "text": "From DB"}],
+            )
+        ]
+    )
+
+    async def _get_pending_action_requests(*, thread_id: UUID):
+        _ = thread_id
+        return [
+            ActionRequest(
+                id=pending_request_id,
+                thread_id=thread_id,
+                tool_name="set_demo_flag",
+                args={"key": "feature_x", "value": True},
+                risk=ToolRisk.CHANGE,
+                status=ActionRequestStatus.PENDING,
+                requested_by_user_id=owner_id,
+                decided_by_user_id=None,
+                decided_at=None,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        ]
+
+    assistant_repo.get_pending_action_requests = _get_pending_action_requests  # type: ignore[attr-defined]
+
+    service = AssistantService(
+        assistant_repo,
+        _FakeRunner(),
+        action_tool_run_service=ActionToolRunService(
+            repository=_InMemoryActionToolRunRepository(
+                action_requests={}, tool_runs={}
+            )
+        ),
+        workflow_todo_service=_FakeWorkflowTodoService(
+            todos=[
+                {
+                    "content": "Preflight",
+                    "status": "completed",
+                    "priority": "high",
+                },
+                {
+                    "content": "Request approval",
+                    "status": "in_progress",
+                    "priority": "high",
+                },
+            ]
+        ),
+        session=_FakeSession(),
+    )
+
+    state = await service.load_state(owner_user_id=owner_id, thread_id=thread_id)
+
+    assert state["workflow"] == [
+        {"content": "Preflight", "status": "completed", "priority": "high"},
+        {
+            "content": "Request approval",
+            "status": "in_progress",
+            "priority": "high",
+        },
+    ]
+    assert state["pendingApprovals"] == [
+        {
+            "actionRequestId": str(pending_request_id),
+            "toolName": "set_demo_flag",
+            "risk": "CHANGE",
+            "arguments": {"key": "feature_x", "value": True},
+            "status": "PENDING",
+        }
+    ]
 
 
 async def test_record_tool_result_rejects_stale_tool_run() -> None:

--- a/apps/api/tests/test_workflow_todo_tool.py
+++ b/apps/api/tests/test_workflow_todo_tool.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
+import pytest
+
 
 async def test_update_workflow_todo_echoes_list() -> None:
     from noa_api.core.tools.workflow_todo import update_workflow_todo
@@ -45,3 +49,39 @@ async def test_update_workflow_todo_rejects_invalid_status() -> None:
 
     assert result["ok"] is False
     assert result["error_code"] == "invalid_todo_status"
+
+
+async def test_update_workflow_todo_persists_workflow_when_thread_context_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from noa_api.core.tools.workflow_todo import update_workflow_todo
+
+    captured: dict[str, object] = {}
+
+    async def _record_replace(self, *, thread_id, todos):
+        captured["thread_id"] = thread_id
+        captured["todos"] = todos
+
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.workflow_todos.WorkflowTodoService.replace_workflow",
+        _record_replace,
+    )
+
+    todos = [
+        {"content": "Preflight", "status": "completed", "priority": "high"},
+        {
+            "content": "Request approval",
+            "status": "in_progress",
+            "priority": "high",
+        },
+    ]
+    thread_id = uuid4()
+
+    result = await update_workflow_todo(
+        todos=todos,
+        session=object(),
+        thread_id=thread_id,
+    )
+
+    assert result == {"ok": True, "todos": todos}
+    assert captured == {"thread_id": thread_id, "todos": todos}


### PR DESCRIPTION
## Summary
- persist thread-scoped workflow todos in Postgres and keep `update_workflow_todo` backward-compatible while writing canonical workflow state
- extend assistant thread state and transport refreshes to return `workflow` and `pendingApprovals` without scanning transcript history
- pass thread execution context into tool execution paths and add regression coverage for workflow persistence and canonical state hydration

## Verification
- ran `uv run alembic upgrade head` in `apps/api`
- ran `uv run pytest -q tests/test_workflow_todo_tool.py tests/test_assistant.py tests/test_assistant_operations.py tests/test_assistant_service.py`

## Issues
- fixes #1
- part of #10