### PR TITLE
fix: replace transcript-derived workflow UI with a canonical dock

### DIFF
--- a/apps/api/alembic/versions/0005_expand_workflow_todo_statuses.py
+++ b/apps/api/alembic/versions/0005_expand_workflow_todo_statuses.py
@@ -1,0 +1,35 @@
+"""expand workflow todo statuses
+
+Revision ID: 0005_expand_workflow_todo_statuses
+Revises: 0004_workflow_todos
+Create Date: 2026-03-16 00:00:01.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0005_expand_workflow_todo_statuses"
+down_revision: Union[str, None] = "0004_workflow_todos"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_workflow_todos_status", "workflow_todos", type_="check")
+    op.create_check_constraint(
+        "ck_workflow_todos_status",
+        "workflow_todos",
+        "status IN ('pending', 'in_progress', 'waiting_on_user', "
+        "'waiting_on_approval', 'completed', 'cancelled')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_workflow_todos_status", "workflow_todos", type_="check")
+    op.create_check_constraint(
+        "ck_workflow_todos_status",
+        "workflow_todos",
+        "status IN ('pending', 'in_progress', 'completed', 'cancelled')",
+    )

--- a/apps/api/src/noa_api/core/tools/registry.py
+++ b/apps/api/src/noa_api/core/tools/registry.py
@@ -204,8 +204,15 @@ _TODO_ITEM_SCHEMA = {
         ),
         "status": {
             "type": "string",
-            "description": "Workflow state. Use pending, in_progress, completed, or cancelled. Only one todo item may be in_progress.",
-            "enum": ["pending", "in_progress", "completed", "cancelled"],
+            "description": "Workflow state. Use pending, in_progress, waiting_on_user, waiting_on_approval, completed, or cancelled. Only one todo item may be in_progress.",
+            "enum": [
+                "pending",
+                "in_progress",
+                "waiting_on_user",
+                "waiting_on_approval",
+                "completed",
+                "cancelled",
+            ],
         },
         "priority": {
             "type": "string",

--- a/apps/api/src/noa_api/core/tools/workflow_todo.py
+++ b/apps/api/src/noa_api/core/tools/workflow_todo.py
@@ -12,8 +12,26 @@ from noa_api.storage.postgres.workflow_todos import (
 )
 
 
-_VALID_TODO_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
+_VALID_TODO_STATUSES = {
+    "pending",
+    "in_progress",
+    "waiting_on_user",
+    "waiting_on_approval",
+    "completed",
+    "cancelled",
+}
 _VALID_TODO_PRIORITIES = {"high", "medium", "low"}
+
+_VALID_TODO_STATUS_LIST = ", ".join(
+    [
+        "pending",
+        "in_progress",
+        "waiting_on_user",
+        "waiting_on_approval",
+        "completed",
+        "cancelled",
+    ]
+)
 
 
 async def _validate_workflow_todos(*, todos: list[dict[str, Any]]) -> dict[str, Any]:
@@ -35,7 +53,7 @@ async def _validate_workflow_todos(*, todos: list[dict[str, Any]]) -> dict[str, 
                 "error_code": "invalid_todo_status",
                 "message": (
                     f"Todo item {index} has invalid status '{status}'. "
-                    "Use pending, in_progress, completed, or cancelled"
+                    f"Use {_VALID_TODO_STATUS_LIST}"
                 ),
             }
         if status == "in_progress":

--- a/apps/api/src/noa_api/storage/postgres/workflow_todos.py
+++ b/apps/api/src/noa_api/storage/postgres/workflow_todos.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal, Protocol, TypedDict
+from typing import Literal, Protocol, TypedDict, cast
 from uuid import UUID
 
 from sqlalchemy import delete, select
@@ -9,7 +9,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from noa_api.storage.postgres.models import WorkflowTodo
 
-WorkflowTodoStatus = Literal["pending", "in_progress", "completed", "cancelled"]
+WorkflowTodoStatus = Literal[
+    "pending",
+    "in_progress",
+    "waiting_on_user",
+    "waiting_on_approval",
+    "completed",
+    "cancelled",
+]
 WorkflowTodoPriority = Literal["high", "medium", "low"]
 
 
@@ -71,26 +78,35 @@ class WorkflowTodoService:
     async def replace_workflow(
         self, *, thread_id: UUID, todos: Sequence[WorkflowTodoItem]
     ) -> list[WorkflowTodoItem]:
-        normalized: list[WorkflowTodoItem] = [
-            {
-                "content": todo["content"],
-                "status": todo["status"],
-                "priority": todo["priority"],
-            }
-            for todo in todos
-        ]
+        normalized: list[WorkflowTodoItem] = []
+        for todo in todos:
+            normalized.append(
+                cast(
+                    WorkflowTodoItem,
+                    {
+                        "content": todo["content"],
+                        "status": cast(WorkflowTodoStatus, todo["status"]),
+                        "priority": cast(WorkflowTodoPriority, todo["priority"]),
+                    },
+                )
+            )
         await self._repository.replace_workflow(thread_id=thread_id, todos=normalized)
         return normalized
 
     async def list_workflow(self, *, thread_id: UUID) -> list[WorkflowTodoItem]:
-        return [
-            {
-                "content": todo.content,
-                "status": todo.status,
-                "priority": todo.priority,
-            }
-            for todo in await self._repository.list_workflow(thread_id=thread_id)
-        ]
+        workflow: list[WorkflowTodoItem] = []
+        for todo in await self._repository.list_workflow(thread_id=thread_id):
+            workflow.append(
+                cast(
+                    WorkflowTodoItem,
+                    {
+                        "content": todo.content,
+                        "status": cast(WorkflowTodoStatus, todo.status),
+                        "priority": cast(WorkflowTodoPriority, todo.priority),
+                    },
+                )
+            )
+        return workflow
 
     async def clear_workflow(self, *, thread_id: UUID) -> None:
         await self._repository.clear_workflow(thread_id=thread_id)

--- a/apps/api/tests/test_tool_result_validation.py
+++ b/apps/api/tests/test_tool_result_validation.py
@@ -19,7 +19,11 @@ def test_validate_tool_result_accepts_workflow_success_payload() -> None:
         result={
             "ok": True,
             "todos": [
-                {"content": "Preflight", "status": "in_progress", "priority": "high"}
+                {
+                    "content": "Request approval",
+                    "status": "waiting_on_approval",
+                    "priority": "high",
+                }
             ],
         },
     )

--- a/apps/api/tests/test_workflow_todo_tool.py
+++ b/apps/api/tests/test_workflow_todo_tool.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import cast
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 async def test_update_workflow_todo_echoes_list() -> None:
@@ -15,6 +17,27 @@ async def test_update_workflow_todo_echoes_list() -> None:
     result = await update_workflow_todo(todos=todos)
     assert result["ok"] is True
     assert result["todos"] == todos
+
+
+async def test_update_workflow_todo_accepts_blocked_statuses() -> None:
+    from noa_api.core.tools.workflow_todo import update_workflow_todo
+
+    todos = [
+        {
+            "content": "Ask user to confirm target",
+            "status": "waiting_on_user",
+            "priority": "high",
+        },
+        {
+            "content": "Request approval",
+            "status": "waiting_on_approval",
+            "priority": "high",
+        },
+    ]
+
+    result = await update_workflow_todo(todos=todos)
+
+    assert result == {"ok": True, "todos": todos}
 
 
 async def test_update_workflow_todo_rejects_multiple_in_progress_items() -> None:
@@ -49,6 +72,8 @@ async def test_update_workflow_todo_rejects_invalid_status() -> None:
 
     assert result["ok"] is False
     assert result["error_code"] == "invalid_todo_status"
+    assert "waiting_on_user" in result["message"]
+    assert "waiting_on_approval" in result["message"]
 
 
 async def test_update_workflow_todo_persists_workflow_when_thread_context_present(
@@ -79,7 +104,7 @@ async def test_update_workflow_todo_persists_workflow_when_thread_context_presen
 
     result = await update_workflow_todo(
         todos=todos,
-        session=object(),
+        session=cast(AsyncSession, object()),
         thread_id=thread_id,
     )
 

--- a/apps/web/components/assistant/claude-thread.tsx
+++ b/apps/web/components/assistant/claude-thread.tsx
@@ -27,9 +27,10 @@ import {
 } from "@/components/assistant/claude-greeting";
 import { ClaudeToolFallback, ClaudeToolGroup } from "@/components/assistant/request-approval-tool-ui";
 import {
+  extractLatestCanonicalWorkflowTodos,
   extractLatestWorkflowTodos,
-  WorkflowTodoCard,
 } from "@/components/assistant/workflow-todo-tool-ui";
+import { WorkflowDock } from "@/components/assistant/workflow-dock";
 import { getAuthUser } from "@/components/lib/auth-store";
 import { useThreadHydration } from "@/components/lib/thread-hydration";
 
@@ -211,9 +212,20 @@ export const ClaudeThread: FC<{
   const { isHydrating } = useThreadHydration();
   const threadStatus = useAssistantState(({ threadListItem }: any) => threadListItem?.status);
   const threadMessages = useAssistantState(({ thread }: any) => thread?.messages);
-  const workflowTodos = useMemo(
-    () => extractLatestWorkflowTodos(threadMessages),
+  const threadIsRunning = useAssistantState(({ thread }: any) =>
+    Array.isArray(thread?.messages)
+      ? thread.messages.some(
+          (message: any) => message?.role === "assistant" && message?.status?.type === "running",
+        )
+      : false,
+  );
+  const canonicalWorkflowTodos = useMemo(
+    () => extractLatestCanonicalWorkflowTodos(threadMessages),
     [threadMessages],
+  );
+  const workflowTodos = useMemo(
+    () => canonicalWorkflowTodos ?? extractLatestWorkflowTodos(threadMessages),
+    [canonicalWorkflowTodos, threadMessages],
   );
   const showHydrationSkeleton = Boolean(isHydrating) && threadStatus !== "new";
 
@@ -255,11 +267,7 @@ export const ClaudeThread: FC<{
 
       <AssistantIf condition={({ thread }) => !thread.isEmpty}>
         <div className="mx-auto w-full max-w-3xl">
-          {workflowTodos.length ? (
-            <div className="mb-3" data-testid="workflow-todo-dock">
-              <WorkflowTodoCard todos={workflowTodos} />
-            </div>
-          ) : null}
+          <WorkflowDock todos={workflowTodos} isRunning={threadIsRunning} />
 
           <ComposerPrimitive.Root className="flex w-full flex-col rounded-2xl border border-border bg-surface p-0.5 shadow-sm transition-shadow duration-200 hover:shadow-md focus-within:shadow-md">
             <div className="m-3.5 flex flex-col gap-3.5">

--- a/apps/web/components/assistant/workflow-dock-state.ts
+++ b/apps/web/components/assistant/workflow-dock-state.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { WorkflowTodoItem } from "@/components/assistant/workflow-todo-tool-ui";
+import { isWorkflowTodoBlocked } from "@/components/assistant/workflow-todo-tool-ui";
+
+export type WorkflowDockPhase = "hide" | "open" | "blocked" | "close" | "clear";
+
+type WorkflowDockStateOptions = {
+  todos: WorkflowTodoItem[];
+  isRunning: boolean;
+  closeDelayMs?: number;
+};
+
+export function useWorkflowDockState({
+  todos,
+  isRunning,
+  closeDelayMs = 400,
+}: WorkflowDockStateOptions) {
+  const [phase, setPhase] = useState<WorkflowDockPhase>("hide");
+  const [isMounted, setIsMounted] = useState(false);
+
+  const hasTodos = todos.length > 0;
+  const hasBlockedTodo = useMemo(
+    () => todos.some((todo) => isWorkflowTodoBlocked(todo.status)),
+    [todos],
+  );
+  const hasIncompleteTodo = useMemo(
+    () => todos.some((todo) => todo.status !== "completed" && todo.status !== "cancelled"),
+    [todos],
+  );
+  const isLive = isRunning || hasBlockedTodo;
+
+  useEffect(() => {
+    if (!hasTodos) {
+      setPhase("hide");
+      setIsMounted(false);
+      return;
+    }
+
+    if (isLive) {
+      setPhase(hasBlockedTodo ? "blocked" : "open");
+      setIsMounted(true);
+      return;
+    }
+
+    if (hasIncompleteTodo) {
+      setPhase("clear");
+      setIsMounted(false);
+      return;
+    }
+
+    setPhase("close");
+    setIsMounted(true);
+
+    const timeoutId = window.setTimeout(() => {
+      setPhase("hide");
+      setIsMounted(false);
+    }, closeDelayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [closeDelayMs, hasBlockedTodo, hasIncompleteTodo, hasTodos, isLive]);
+
+  return {
+    phase,
+    isMounted,
+    isBlocked: phase === "blocked",
+  };
+}

--- a/apps/web/components/assistant/workflow-dock.test.tsx
+++ b/apps/web/components/assistant/workflow-dock.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorkflowDock } from "./workflow-dock";
+
+describe("WorkflowDock", () => {
+  it("prioritizes in-progress steps as the active step", () => {
+    render(
+      <WorkflowDock
+        isRunning
+        todos={[
+          { content: "Preflight", status: "completed", priority: "high" },
+          { content: "Apply change", status: "in_progress", priority: "high" },
+          { content: "Confirm result", status: "pending", priority: "medium" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("workflow-active-step")).toHaveTextContent("Apply change");
+  });
+
+  it("surfaces blocked statuses distinctly when execution is paused", () => {
+    render(
+      <WorkflowDock
+        isRunning={false}
+        todos={[
+          { content: "Request approval", status: "waiting_on_approval", priority: "high" },
+          { content: "Apply change", status: "pending", priority: "high" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Workflow paused")).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-active-step")).toHaveTextContent("Request approval");
+    expect(screen.getByText(/waiting on approval/i)).toBeInTheDocument();
+  });
+
+  it("hides stale incomplete workflows after a run is no longer live", () => {
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <WorkflowDock
+        isRunning
+        todos={[{ content: "Apply change", status: "in_progress", priority: "high" }]}
+      />,
+    );
+
+    rerender(
+      <WorkflowDock
+        isRunning={false}
+        todos={[{ content: "Apply change", status: "pending", priority: "high" }]}
+      />,
+    );
+
+    expect(screen.queryByTestId("workflow-todo-dock")).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/components/assistant/workflow-dock.tsx
+++ b/apps/web/components/assistant/workflow-dock.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { DotFilledIcon } from "@radix-ui/react-icons";
+
+import type { WorkflowTodoItem } from "@/components/assistant/workflow-todo-tool-ui";
+import {
+  getWorkflowTodoStatusStyle,
+  isWorkflowTodoBlocked,
+} from "@/components/assistant/workflow-todo-tool-ui";
+import { useWorkflowDockState } from "@/components/assistant/workflow-dock-state";
+
+function getActiveTodoIndex(todos: WorkflowTodoItem[]): number {
+  const inProgressIndex = todos.findIndex((todo) => todo.status === "in_progress");
+  if (inProgressIndex >= 0) return inProgressIndex;
+
+  const blockedIndex = todos.findIndex((todo) => isWorkflowTodoBlocked(todo.status));
+  if (blockedIndex >= 0) return blockedIndex;
+
+  const pendingIndex = todos.findIndex((todo) => todo.status === "pending");
+  if (pendingIndex >= 0) return pendingIndex;
+
+  for (let index = todos.length - 1; index >= 0; index -= 1) {
+    if (todos[index]?.status === "completed") return index;
+  }
+
+  return todos.length ? 0 : -1;
+}
+
+function getDockCopy(phase: ReturnType<typeof useWorkflowDockState>["phase"]) {
+  if (phase === "blocked") {
+    return {
+      eyebrow: "Workflow paused",
+      detail: "Waiting for input before the next step can continue.",
+    };
+  }
+
+  if (phase === "close") {
+    return {
+      eyebrow: "Workflow complete",
+      detail: "All recorded steps finished successfully.",
+    };
+  }
+
+  return {
+    eyebrow: "Workflow running",
+    detail: "Live checklist from the canonical assistant state.",
+  };
+}
+
+export function WorkflowDock({ todos, isRunning }: { todos: WorkflowTodoItem[]; isRunning: boolean }) {
+  const { phase, isBlocked, isMounted } = useWorkflowDockState({ todos, isRunning });
+  const activeTodoIndex = getActiveTodoIndex(todos);
+
+  if (!isMounted || !todos.length) {
+    return null;
+  }
+
+  const copy = getDockCopy(phase);
+
+  return (
+    <div
+      className={[
+        "mb-3 overflow-hidden rounded-xl border border-border bg-surface shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.035),0_0_0_0.5px_rgba(0,0,0,0.08)] transition-all duration-200",
+        phase === "close" ? "opacity-70" : "opacity-100",
+      ].join(" ")}
+      data-testid="workflow-todo-dock"
+      data-workflow-phase={phase}
+    >
+      <div className="flex items-start justify-between gap-3 border-b border-border bg-surface-2 px-4 py-3">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-text">{copy.eyebrow}</div>
+          <div className="mt-0.5 text-xs text-muted">{copy.detail}</div>
+        </div>
+        <div
+          className={[
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em]",
+            isBlocked ? "bg-amber-100 text-amber-900" : "bg-accent/15 text-accent",
+          ].join(" ")}
+        >
+          {isBlocked ? "blocked" : phase === "close" ? "done" : "live"}
+        </div>
+      </div>
+
+      <div className="px-4 py-3">
+        <ul className="space-y-2">
+          {todos.map((todo, index) => {
+            const style = getWorkflowTodoStatusStyle(todo.status);
+            const isActive = index === activeTodoIndex;
+            const isTodoBlocked = isWorkflowTodoBlocked(todo.status);
+            return (
+              <li
+                key={`${todo.content}-${index}`}
+                className={[
+                  "flex items-start justify-between gap-3 rounded-lg border px-3 py-2 transition-colors",
+                  isActive
+                    ? isTodoBlocked
+                      ? "border-amber-300 bg-amber-50/70"
+                      : "border-accent/30 bg-accent/5"
+                    : "border-border bg-bg/40",
+                ].join(" ")}
+                data-testid={isActive ? "workflow-active-step" : undefined}
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
+                    <DotFilledIcon width={14} height={14} />
+                    {isActive ? (isTodoBlocked ? "Blocked step" : "Current step") : `Step ${index + 1}`}
+                  </div>
+                  <div className="mt-1 text-sm text-text">{todo.content}</div>
+                </div>
+                <div
+                  className={[
+                    "shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px]",
+                    style.className,
+                  ].join(" ")}
+                >
+                  <style.Icon width={12} height={12} />
+                  <span className="leading-none">{style.label}</span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/assistant/workflow-todo-tool-ui.tsx
+++ b/apps/web/components/assistant/workflow-todo-tool-ui.tsx
@@ -3,14 +3,22 @@
 import { makeAssistantToolUI } from "@assistant-ui/react";
 import { CheckIcon, Cross2Icon, DotFilledIcon } from "@radix-ui/react-icons";
 
-type WorkflowTodoStatus = "pending" | "in_progress" | "completed" | "cancelled";
-type WorkflowTodoPriority = "high" | "medium" | "low";
+export type WorkflowTodoStatus =
+  | "pending"
+  | "in_progress"
+  | "waiting_on_user"
+  | "waiting_on_approval"
+  | "completed"
+  | "cancelled";
+export type WorkflowTodoPriority = "high" | "medium" | "low";
 
 export type WorkflowTodoItem = {
   content: string;
   status: WorkflowTodoStatus;
   priority: WorkflowTodoPriority;
 };
+
+export const BLOCKED_WORKFLOW_TODO_STATUSES = ["waiting_on_user", "waiting_on_approval"] as const;
 
 type StatusStyle = {
   label: string;
@@ -27,6 +35,16 @@ const STATUS_STYLES: Record<WorkflowTodoStatus, StatusStyle> = {
   in_progress: {
     label: "in progress",
     className: "bg-accent/15 text-accent",
+    Icon: DotFilledIcon,
+  },
+  waiting_on_user: {
+    label: "waiting on user",
+    className: "bg-amber-100 text-amber-900",
+    Icon: DotFilledIcon,
+  },
+  waiting_on_approval: {
+    label: "waiting on approval",
+    className: "bg-sky-100 text-sky-900",
     Icon: DotFilledIcon,
   },
   completed: {
@@ -48,6 +66,8 @@ function isTodoItem(value: unknown): value is WorkflowTodoItem {
     typeof record.content === "string" &&
     (record.status === "pending" ||
       record.status === "in_progress" ||
+      record.status === "waiting_on_user" ||
+      record.status === "waiting_on_approval" ||
       record.status === "completed" ||
       record.status === "cancelled") &&
     (record.priority === "high" ||
@@ -56,10 +76,40 @@ function isTodoItem(value: unknown): value is WorkflowTodoItem {
   );
 }
 
+function coerceRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
 export function coerceTodos(value: unknown): WorkflowTodoItem[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const todos = value.filter(isTodoItem);
   return todos.length ? todos : [];
+}
+
+export function getWorkflowTodoStatusStyle(status: WorkflowTodoStatus): StatusStyle {
+  return STATUS_STYLES[status] ?? STATUS_STYLES.pending;
+}
+
+export function isWorkflowTodoBlocked(status: WorkflowTodoStatus): boolean {
+  return BLOCKED_WORKFLOW_TODO_STATUSES.includes(
+    status as (typeof BLOCKED_WORKFLOW_TODO_STATUSES)[number],
+  );
+}
+
+export function extractLatestCanonicalWorkflowTodos(messages: unknown): WorkflowTodoItem[] | undefined {
+  if (!Array.isArray(messages)) return undefined;
+
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const message = coerceRecord(messages[messageIndex]);
+    const metadata = coerceRecord(message?.metadata);
+    const custom = coerceRecord(metadata?.custom);
+    if (!custom || !("workflow" in custom)) continue;
+    return coerceTodos(custom.workflow);
+  }
+
+  return undefined;
 }
 
 export function extractLatestWorkflowTodos(messages: unknown): WorkflowTodoItem[] {
@@ -99,7 +149,7 @@ export function WorkflowTodoCard({ todos }: { todos: WorkflowTodoItem[] }) {
         {todos.length ? (
           <ul className="space-y-2">
             {todos.map((todo, index) => {
-              const style = STATUS_STYLES[todo.status] ?? STATUS_STYLES.pending;
+              const style = getWorkflowTodoStatusStyle(todo.status);
               const Icon = style.Icon;
               return (
                 <li

--- a/apps/web/components/claude/claude-thread.test.tsx
+++ b/apps/web/components/claude/claude-thread.test.tsx
@@ -29,13 +29,20 @@ vi.mock("@/components/assistant/request-approval-tool-ui", () => ({
 }));
 
 vi.mock("@/components/assistant/workflow-todo-tool-ui", () => ({
-  WorkflowTodoCard: ({ todos }: { todos: Array<{ content: string }> }) => (
-    <div data-testid="workflow-card">{todos.map((todo) => todo.content).join(", ")}</div>
-  ),
+  extractLatestCanonicalWorkflowTodos: (messages: any[]) => {
+    const last = messages[messages.length - 1];
+    return last?.metadata?.custom?.workflow;
+  },
   extractLatestWorkflowTodos: (messages: any[]) => {
     const last = messages[messages.length - 1];
     return last?.metadata?.todos ?? [];
   },
+}));
+
+vi.mock("@/components/assistant/workflow-dock", () => ({
+  WorkflowDock: ({ todos }: { todos: Array<{ content: string }> }) => (
+    <div data-testid="workflow-card">{todos.map((todo) => todo.content).join(", ")}</div>
+  ),
 }));
 
 vi.mock("@/components/lib/thread-hydration", () => ({
@@ -231,20 +238,36 @@ describe("ClaudeThread", () => {
     expect(screen.queryByText(/Morning, Casey/)).not.toBeInTheDocument();
   });
 
-  it("pins the latest workflow todo card above the composer", () => {
+  it("pins the canonical workflow dock above the composer", () => {
     mockThreadIsEmpty = false;
     mockThreadMessages = [
       {
         metadata: {
-          todos: [{ content: "Delete user", status: "in_progress", priority: "high" }],
+          custom: {
+            workflow: [{ content: "Delete user", status: "in_progress", priority: "high" }],
+          },
         },
       },
     ];
 
     render(<ClaudeThread />);
 
-    expect(screen.getByTestId("workflow-todo-dock")).toBeInTheDocument();
     expect(screen.getByTestId("workflow-card")).toHaveTextContent("Delete user");
+  });
+
+  it("falls back to transcript-derived workflow for older threads", () => {
+    mockThreadIsEmpty = false;
+    mockThreadMessages = [
+      {
+        metadata: {
+          todos: [{ content: "Legacy workflow", status: "pending", priority: "high" }],
+        },
+      },
+    ];
+
+    render(<ClaudeThread />);
+
+    expect(screen.getByTestId("workflow-card")).toHaveTextContent("Legacy workflow");
   });
 
   it("does not render the assistant disclaimer footer", () => {

--- a/apps/web/components/lib/assistant-transport-converter.test.ts
+++ b/apps/web/components/lib/assistant-transport-converter.test.ts
@@ -112,6 +112,55 @@ describe("convertAssistantState", () => {
     expect(toolPart?.isError).toBe(false);
   });
 
+  it("attaches canonical workflow metadata to the latest message", () => {
+    const converted = convertAssistantState(
+      {
+        isRunning: false,
+        workflow: [
+          {
+            content: "Request approval",
+            status: "waiting_on_approval",
+            priority: "high",
+          },
+        ],
+        pendingApprovals: [
+          {
+            actionRequestId: "approval-1",
+            toolName: "set_demo_flag",
+            risk: "CHANGE",
+            arguments: { key: "feature_x", value: true },
+            status: "PENDING",
+          },
+        ],
+        messages: [
+          {
+            id: "m1",
+            role: "assistant",
+            parts: [{ type: "text", text: "Working on it" }],
+          },
+        ],
+      },
+      { pendingCommands: [], isSending: false },
+    );
+
+    expect((converted.messages[0] as any)?.metadata?.custom?.workflow).toEqual([
+      {
+        content: "Request approval",
+        status: "waiting_on_approval",
+        priority: "high",
+      },
+    ]);
+    expect((converted.messages[0] as any)?.metadata?.custom?.pendingApprovals).toEqual([
+      {
+        actionRequestId: "approval-1",
+        toolName: "set_demo_flag",
+        risk: "CHANGE",
+        arguments: { key: "feature_x", value: true },
+        status: "PENDING",
+      },
+    ]);
+  });
+
   it("drops proposal tool calls", () => {
     const converted = convertAssistantState(
       {

--- a/apps/web/components/lib/assistant-transport-converter.ts
+++ b/apps/web/components/lib/assistant-transport-converter.ts
@@ -1,7 +1,19 @@
 import type { ThreadMessage } from "@assistant-ui/react";
 
+import type { WorkflowTodoItem } from "@/components/assistant/workflow-todo-tool-ui";
+
+type AssistantPendingApproval = {
+  actionRequestId: string;
+  toolName: string;
+  risk: string;
+  arguments: Record<string, unknown>;
+  status: string;
+};
+
 export type AssistantState = {
   messages: Array<{ id?: string; role: string; parts: Array<Record<string, unknown>> }>;
+  workflow?: WorkflowTodoItem[];
+  pendingApprovals?: AssistantPendingApproval[];
   isRunning: boolean;
 };
 
@@ -23,6 +35,37 @@ type ToolResultData = {
 
 const isEmptyAssistantMessage = (message: ThreadMessage): boolean => {
   return message.role === "assistant" && Array.isArray(message.content) && message.content.length === 0;
+};
+
+const attachCanonicalMetadata = (
+  messages: ThreadMessage[],
+  state: Pick<AssistantState, "workflow" | "pendingApprovals">,
+) => {
+  if (!messages.length) {
+    return messages;
+  }
+
+  const lastMessage = messages[messages.length - 1] as ThreadMessage & {
+    metadata?: Record<string, unknown>;
+  };
+
+  const lastMetadata = coerceRecord(lastMessage.metadata) ?? {};
+  const custom = coerceRecord(lastMetadata.custom) ?? {};
+
+  const nextMessages = [...messages];
+  nextMessages[messages.length - 1] = {
+    ...lastMessage,
+    metadata: {
+      ...lastMetadata,
+      custom: {
+        ...custom,
+        workflow: Array.isArray(state.workflow) ? state.workflow : [],
+        pendingApprovals: Array.isArray(state.pendingApprovals) ? state.pendingApprovals : [],
+      },
+    },
+  } as ThreadMessage;
+
+  return nextMessages;
 };
 
 const partsToContent = (
@@ -229,8 +272,9 @@ export function convertAssistantState(
   }
 
   return {
-    messages: [...persistedMessages, ...optimisticMessages].filter(
-      (message) => !isEmptyAssistantMessage(message),
+    messages: attachCanonicalMetadata(
+      [...persistedMessages, ...optimisticMessages].filter((message) => !isEmptyAssistantMessage(message)),
+      state,
     ),
     isRunning: transportIsRunning,
   };


### PR DESCRIPTION
## Summary
- render the assistant workflow dock from canonical assistant transport state instead of transcript tool-call scanning
- add a dock state machine with deterministic active-step selection and distinct blocked states for `waiting_on_user` and `waiting_on_approval`
- expand backend workflow status validation and persistence so blocked workflow states round-trip through the API and database

## Implementation Details
- `apps/web/components/lib/assistant-transport-converter.ts` now threads canonical `workflow` and `pendingApprovals` onto message metadata so the thread UI can read persisted workflow state during hydration and live transport updates
- `apps/web/components/assistant/workflow-dock.tsx` and `apps/web/components/assistant/workflow-dock-state.ts` add the new dock lifecycle (`hide`, `open`, `blocked`, `close`, `clear`) and deterministic active-step prioritization (`in_progress`, blocked, `pending`, then last `completed`)
- `apps/web/components/assistant/claude-thread.tsx` now prefers canonical workflow data and only falls back to transcript extraction for older threads that do not have canonical workflow metadata yet
- backend workflow status support now includes `waiting_on_user` and `waiting_on_approval` across the tool registry, validator, storage types, tests, and a new Alembic migration in `apps/api/alembic/versions/0005_expand_workflow_todo_statuses.py`

## Testing
- `cd apps/api && uv run pytest -q tests/test_workflow_todo_tool.py tests/test_tool_result_validation.py`
- `cd apps/api && uv run pytest -q tests/test_assistant.py tests/test_assistant_service.py -k workflow`
- `cd apps/web && npm test -- components/lib/assistant-transport-converter.test.ts components/assistant/workflow-dock.test.tsx components/claude/claude-thread.test.tsx components/claude/workflow-todo-tool-ui.test.tsx`
- `cd apps/web && npm run build`

## Notes
- `cd apps/api && uv run ruff check src tests` still reports pre-existing unrelated F403/F401 issues in untouched modules
- `cd apps/web && npm test` still fails in the existing `components/admin/admin-sidebar-shell.test.tsx` suite with `Threads is only available inside <AssistantProvider />`, which is unrelated to this change

Fixes #2
Tracks #10