### PR TITLE
fix(api): add deterministic WHM workflow templates

### DIFF
--- a/apps/api/src/noa_api/api/assistant/assistant_action_operations.py
+++ b/apps/api/src/noa_api/api/assistant/assistant_action_operations.py
@@ -29,6 +29,12 @@ from noa_api.core.agent.runner import (
 from noa_api.core.tool_error_sanitizer import SanitizedToolError, sanitize_tool_error
 from noa_api.core.tools.argument_validation import validate_tool_arguments
 from noa_api.core.tools.registry import get_tool_definition
+from noa_api.core.workflows.registry import (
+    build_workflow_todos,
+    collect_recent_preflight_evidence,
+    fetch_postflight_result,
+    persist_workflow_todos,
+)
 from noa_api.storage.postgres.action_tool_runs import ActionToolRunService
 from noa_api.storage.postgres.lifecycle import ActionRequestStatus, ToolRisk
 from noa_api.storage.postgres.models import ActionRequest, ToolRun
@@ -78,6 +84,7 @@ async def deny_action_request(
     action_request_id: str | None,
     repository: AssistantMessageAuditRepositoryProtocol,
     action_tool_run_service: ActionToolRunService,
+    session: AsyncSession | None = None,
 ) -> None:
     request = await require_pending_action_request(
         owner_user_id=owner_user_id,
@@ -95,6 +102,24 @@ async def deny_action_request(
         raise action_request_already_decided_error() from exc
     if denied is None:
         raise action_request_not_found_error()
+
+    tool = get_tool_definition(denied.tool_name)
+    if tool is not None and tool.workflow_family is not None:
+        working_messages = await _list_working_messages(
+            repository=repository,
+            thread_id=thread_id,
+        )
+        await persist_workflow_todos(
+            session=session,
+            thread_id=thread_id,
+            todos=build_workflow_todos(
+                tool_name=denied.tool_name,
+                workflow_family=tool.workflow_family,
+                args=denied.args,
+                phase="denied",
+                preflight_evidence=collect_recent_preflight_evidence(working_messages),
+            ),
+        )
 
     with log_context(
         action_request_id=str(denied.id),
@@ -319,6 +344,24 @@ async def execute_approved_tool_run(
         )
         return
 
+    working_messages = await _list_working_messages(
+        repository=repository,
+        thread_id=thread_id,
+    )
+    preflight_evidence = collect_recent_preflight_evidence(working_messages)
+    if tool.workflow_family is not None:
+        await persist_workflow_todos(
+            session=session,
+            thread_id=thread_id,
+            todos=build_workflow_todos(
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                args=approved_request.args,
+                phase="executing",
+                preflight_evidence=preflight_evidence,
+            ),
+        )
+
     try:
         validate_tool_arguments(tool=tool, args=approved_request.args)
         result = await _execute_tool(
@@ -337,6 +380,27 @@ async def execute_approved_tool_run(
             if completed is not None and isinstance(completed.result, dict)
             else result
         )
+        postflight_result: dict[str, object] | None = None
+        if tool.workflow_family is not None:
+            postflight_result = await fetch_postflight_result(
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                args=approved_request.args,
+                session=session,
+            )
+            await persist_workflow_todos(
+                session=session,
+                thread_id=thread_id,
+                todos=build_workflow_todos(
+                    tool_name=approved_request.tool_name,
+                    workflow_family=tool.workflow_family,
+                    args=approved_request.args,
+                    phase="completed",
+                    preflight_evidence=preflight_evidence,
+                    result=persisted_result,
+                    postflight_result=postflight_result,
+                ),
+            )
         await repository.create_message(
             thread_id=thread_id,
             role="tool",
@@ -374,6 +438,19 @@ async def execute_approved_tool_run(
                 "user_id": str(owner_user_id),
             },
         )
+        if tool.workflow_family is not None:
+            await persist_workflow_todos(
+                session=session,
+                thread_id=thread_id,
+                todos=build_workflow_todos(
+                    tool_name=approved_request.tool_name,
+                    workflow_family=tool.workflow_family,
+                    args=approved_request.args,
+                    phase="failed",
+                    preflight_evidence=preflight_evidence,
+                    error_code=sanitized_error.error_code,
+                ),
+            )
         await _persist_failed_tool_run(
             started_tool_run=started_tool_run,
             approved_request=approved_request,
@@ -416,6 +493,22 @@ async def _validate_approved_tool_preflight(
         working_messages=working_messages,
         requested_server_id=requested_server_id,
     )
+
+
+async def _list_working_messages(
+    *,
+    repository: AssistantMessageAuditRepositoryProtocol,
+    thread_id: UUID,
+) -> list[dict[str, object]]:
+    messages = await repository.list_messages(thread_id=thread_id)
+    working_messages: list[dict[str, object]] = []
+    for message in messages:
+        role = getattr(message, "role", None)
+        parts = getattr(message, "content", None)
+        if not isinstance(role, str) or not isinstance(parts, list):
+            continue
+        working_messages.append({"role": role, "parts": parts})
+    return working_messages
 
 
 async def _execute_tool(

--- a/apps/api/src/noa_api/api/routes/assistant.py
+++ b/apps/api/src/noa_api/api/routes/assistant.py
@@ -342,6 +342,7 @@ class AssistantService:
             action_request_id=action_request_id,
             repository=self._repository,
             action_tool_run_service=self._action_tool_run_service,
+            session=self._session,
         )
 
     async def run_agent_turn(

--- a/apps/api/src/noa_api/core/agent/runner.py
+++ b/apps/api/src/noa_api/core/agent/runner.py
@@ -21,6 +21,12 @@ from noa_api.core.tools.registry import (
     get_tool_definition,
     get_tool_registry,
 )
+from noa_api.core.workflows.registry import (
+    build_workflow_todos,
+    collect_recent_preflight_evidence,
+    collect_recent_preflight_results,
+    persist_workflow_todos,
+)
 from noa_api.storage.postgres.action_tool_runs import ActionToolRunService
 from noa_api.storage.postgres.lifecycle import ToolRisk
 from noa_api.storage.postgres.whm_servers import SQLWHMServerRepository
@@ -499,6 +505,13 @@ class AgentRunner:
             )
             if validation_error is not None:
                 tool_call_id = f"invalid-{uuid4()}"
+                await self._persist_deterministic_workflow_for_validation_error(
+                    tool=tool,
+                    args=args,
+                    working_messages=working_messages,
+                    thread_id=thread_id,
+                    error=validation_error,
+                )
                 return ProcessedToolCall(
                     messages=_tool_error_messages(
                         tool=tool,
@@ -514,6 +527,19 @@ class AgentRunner:
                 args=args,
                 risk=tool.risk,
                 requested_by_user_id=requested_by_user_id,
+            )
+            await persist_workflow_todos(
+                session=self._session,
+                thread_id=thread_id,
+                todos=build_workflow_todos(
+                    tool_name=tool.name,
+                    workflow_family=tool.workflow_family,
+                    args=args,
+                    phase="waiting_on_approval",
+                    preflight_evidence=collect_recent_preflight_evidence(
+                        working_messages
+                    ),
+                ),
             )
             return ProcessedToolCall(
                 messages=[
@@ -654,6 +680,31 @@ class AgentRunner:
             if preflight_error is not None:
                 return preflight_error
         return None
+
+    async def _persist_deterministic_workflow_for_validation_error(
+        self,
+        *,
+        tool: ToolDefinition,
+        args: dict[str, object],
+        working_messages: list[dict[str, object]],
+        thread_id: UUID,
+        error: SanitizedToolError,
+    ) -> None:
+        if error.error_code != "invalid_tool_arguments":
+            return
+        if not error.details or "Missing required field 'reason'" not in error.details:
+            return
+        await persist_workflow_todos(
+            session=self._session,
+            thread_id=thread_id,
+            todos=build_workflow_todos(
+                tool_name=tool.name,
+                workflow_family=tool.workflow_family,
+                args=args,
+                phase="waiting_on_user",
+                preflight_evidence=collect_recent_preflight_evidence(working_messages),
+            ),
+        )
 
     async def _execute_tool(
         self,
@@ -815,73 +866,6 @@ def _messages_since_last_user(
     return working_messages[last_user_index + 1 :]
 
 
-def _collect_recent_preflight_evidence(
-    working_messages: list[dict[str, object]],
-) -> list[dict[str, object]]:
-    tool_calls_by_id: dict[str, dict[str, object]] = {}
-    evidence: list[dict[str, object]] = []
-
-    for message in _messages_since_last_user(working_messages):
-        parts = message.get("parts")
-        if not isinstance(parts, list):
-            continue
-        for raw_part in parts:
-            part = _coerce_part_record(raw_part)
-            if part is None:
-                continue
-
-            part_type = part.get("type")
-            tool_name = part.get("toolName")
-            if not isinstance(tool_name, str) or not tool_name.startswith(
-                "whm_preflight_"
-            ):
-                continue
-
-            tool_call_id = part.get("toolCallId")
-            if not isinstance(tool_call_id, str) or not tool_call_id:
-                continue
-
-            if part_type == "tool-call":
-                args = part.get("args")
-                args_obj = args if isinstance(args, dict) else {}
-                tool_calls_by_id[tool_call_id] = {
-                    "toolName": tool_name,
-                    "args": json_safe(args_obj),
-                }
-                continue
-
-            if part_type != "tool-result" or part.get("isError") is True:
-                continue
-
-            result = part.get("result")
-            if not isinstance(result, dict):
-                continue
-
-            call = tool_calls_by_id.get(tool_call_id, {})
-            entry: dict[str, object] = {
-                "toolName": tool_name,
-                "result": json_safe(result),
-            }
-            call_args = call.get("args")
-            if isinstance(call_args, dict):
-                entry["args"] = call_args
-            evidence.append(entry)
-
-    return evidence
-
-
-def _collect_recent_preflight_results(
-    working_messages: list[dict[str, object]],
-) -> list[dict[str, object]]:
-    return [
-        {
-            "toolName": item["toolName"],
-            "result": item["result"],
-        }
-        for item in _collect_recent_preflight_evidence(working_messages)
-    ]
-
-
 def _require_matching_preflight(
     *,
     tool_name: str,
@@ -928,7 +912,7 @@ def _require_account_preflight(
 
     evidence = [
         item
-        for item in _collect_recent_preflight_evidence(working_messages)
+        for item in collect_recent_preflight_evidence(working_messages)
         if item.get("toolName") == "whm_preflight_account"
         and isinstance(item.get("result"), dict)
         and cast(dict[str, object], item["result"]).get("ok") is True
@@ -982,7 +966,7 @@ def _require_csf_preflight(
 
     evidence = [
         item
-        for item in _collect_recent_preflight_evidence(working_messages)
+        for item in collect_recent_preflight_evidence(working_messages)
         if item.get("toolName") == "whm_preflight_csf_entries"
         and isinstance(item.get("result"), dict)
         and cast(dict[str, object], item["result"]).get("ok") is True
@@ -1189,7 +1173,7 @@ def _build_approval_context(
     args: dict[str, object],
     working_messages: list[dict[str, object]],
 ) -> dict[str, object]:
-    preflight_results = _collect_recent_preflight_results(working_messages)
+    preflight_results = collect_recent_preflight_results(working_messages)
     return {
         "activity": _describe_activity(tool_name, args),
         "argumentSummary": _summarize_arguments(args),

--- a/apps/api/src/noa_api/core/tools/registry.py
+++ b/apps/api/src/noa_api/core/tools/registry.py
@@ -46,6 +46,7 @@ class ToolDefinition:
     execute: ToolExecutor
     prompt_hints: tuple[str, ...] = ()
     result_schema: ToolResultSchema | None = None
+    workflow_family: str | None = None
 
 
 def _object_schema(
@@ -615,6 +616,7 @@ _MVP_TOOLS: tuple[ToolDefinition, ...] = (
             "Failures return `ok: false` with `error_code` and `message`.",
         ),
         result_schema=_ACCOUNT_CHANGE_RESULT_SCHEMA,
+        workflow_family="whm-account-lifecycle",
     ),
     ToolDefinition(
         name="whm_unsuspend_account",
@@ -635,6 +637,7 @@ _MVP_TOOLS: tuple[ToolDefinition, ...] = (
             "Failures return `ok: false` with `error_code` and `message`.",
         ),
         result_schema=_ACCOUNT_CHANGE_RESULT_SCHEMA,
+        workflow_family="whm-account-lifecycle",
     ),
     ToolDefinition(
         name="whm_change_contact_email",
@@ -659,6 +662,7 @@ _MVP_TOOLS: tuple[ToolDefinition, ...] = (
             "Failures return `ok: false` with `error_code` and `message`.",
         ),
         result_schema=_ACCOUNT_CHANGE_RESULT_SCHEMA,
+        workflow_family="whm-account-contact-email",
     ),
     ToolDefinition(
         name="whm_csf_unblock",
@@ -678,6 +682,7 @@ _MVP_TOOLS: tuple[ToolDefinition, ...] = (
             "Batch result contract: returns `results` entries per target with `status` `changed`, `no-op`, or `error`, plus `verdict`, `matches`, and `error_code` when relevant.",
         ),
         result_schema=_CSF_BATCH_RESULT_SCHEMA,
+        workflow_family="whm-csf-batch-change",
     ),
     ToolDefinition(
         name="whm_csf_allowlist_remove",
@@ -697,6 +702,7 @@ _MVP_TOOLS: tuple[ToolDefinition, ...] = (
             "Batch result contract: returns `results` entries per target with `status` `changed`, `no-op`, or `error`, plus `verdict`, `matches`, and `error_code` when relevant.",
         ),
         result_schema=_CSF_BATCH_RESULT_SCHEMA,
+        workflow_family="whm-csf-batch-change",
     ),
     ToolDefinition(
         name="whm_csf_allowlist_add_ttl",
@@ -726,6 +732,7 @@ _MVP_TOOLS: tuple[ToolDefinition, ...] = (
             "Batch result contract: returns `results` entries per target with `status` `changed`, `no-op`, or `error`, plus `verdict`, `matches`, and `error_code` when relevant.",
         ),
         result_schema=_CSF_BATCH_RESULT_SCHEMA,
+        workflow_family="whm-csf-batch-change",
     ),
     ToolDefinition(
         name="whm_csf_denylist_add_ttl",
@@ -755,6 +762,7 @@ _MVP_TOOLS: tuple[ToolDefinition, ...] = (
             "Batch result contract: returns `results` entries per target with `status` `changed`, `no-op`, or `error`, plus `verdict`, `matches`, and `error_code` when relevant.",
         ),
         result_schema=_CSF_BATCH_RESULT_SCHEMA,
+        workflow_family="whm-csf-batch-change",
     ),
 )
 _MVP_TOOL_INDEX = {tool.name: tool for tool in _MVP_TOOLS}

--- a/apps/api/src/noa_api/core/workflows/__init__.py
+++ b/apps/api/src/noa_api/core/workflows/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/apps/api/src/noa_api/core/workflows/registry.py
+++ b/apps/api/src/noa_api/core/workflows/registry.py
@@ -1,0 +1,881 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from noa_api.core.json_safety import json_safe
+from noa_api.core.tools.registry import get_tool_definition
+from noa_api.storage.postgres.workflow_todos import (
+    SQLWorkflowTodoRepository,
+    WorkflowTodoItem,
+    WorkflowTodoService,
+)
+from noa_api.whm.tools.preflight_tools import (
+    whm_preflight_account,
+    whm_preflight_csf_entries,
+)
+
+WorkflowTemplatePhase = Literal[
+    "waiting_on_user",
+    "waiting_on_approval",
+    "executing",
+    "completed",
+    "denied",
+    "failed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowTemplateContext:
+    tool_name: str
+    args: dict[str, object]
+    phase: WorkflowTemplatePhase
+    preflight_evidence: list[dict[str, object]]
+    result: dict[str, object] | None = None
+    postflight_result: dict[str, object] | None = None
+    error_code: str | None = None
+
+
+def get_workflow_family(
+    tool_name: str, *, workflow_family: str | None = None
+) -> str | None:
+    if workflow_family is not None:
+        return workflow_family
+    tool = get_tool_definition(tool_name)
+    if tool is None:
+        return None
+    return tool.workflow_family
+
+
+def build_workflow_todos(
+    *,
+    tool_name: str,
+    workflow_family: str | None = None,
+    args: dict[str, object],
+    phase: WorkflowTemplatePhase,
+    preflight_evidence: list[dict[str, object]],
+    result: dict[str, object] | None = None,
+    postflight_result: dict[str, object] | None = None,
+    error_code: str | None = None,
+) -> list[WorkflowTodoItem] | None:
+    family = get_workflow_family(tool_name, workflow_family=workflow_family)
+    context = WorkflowTemplateContext(
+        tool_name=tool_name,
+        args=args,
+        phase=phase,
+        preflight_evidence=preflight_evidence,
+        result=result,
+        postflight_result=postflight_result,
+        error_code=error_code,
+    )
+    if family == "whm-account-lifecycle":
+        return _build_whm_account_lifecycle_workflow(context)
+    if family == "whm-account-contact-email":
+        return _build_whm_account_contact_email_workflow(context)
+    if family == "whm-csf-batch-change":
+        return _build_whm_csf_batch_workflow(context)
+    return None
+
+
+async def persist_workflow_todos(
+    *,
+    session: AsyncSession | None,
+    thread_id: UUID,
+    todos: list[WorkflowTodoItem] | None,
+) -> None:
+    if session is None or todos is None:
+        return
+    workflow_todo_service = WorkflowTodoService(
+        repository=SQLWorkflowTodoRepository(session)
+    )
+    await workflow_todo_service.replace_workflow(thread_id=thread_id, todos=todos)
+
+
+async def fetch_postflight_result(
+    *,
+    tool_name: str,
+    workflow_family: str | None = None,
+    args: dict[str, object],
+    session: AsyncSession | None,
+) -> dict[str, object] | None:
+    if session is None:
+        return None
+    if get_workflow_family(tool_name, workflow_family=workflow_family) not in {
+        "whm-account-lifecycle",
+        "whm-account-contact-email",
+        "whm-csf-batch-change",
+    }:
+        return None
+
+    family = get_workflow_family(tool_name, workflow_family=workflow_family)
+
+    server_ref = _normalized_text(args.get("server_ref"))
+    if server_ref is None:
+        return None
+    if family in {"whm-account-lifecycle", "whm-account-contact-email"}:
+        username = _normalized_text(args.get("username"))
+        if username is None:
+            return None
+        result = await whm_preflight_account(
+            session=session,
+            server_ref=server_ref,
+            username=username,
+        )
+        return result if isinstance(result, dict) else None
+
+    targets = _normalized_string_list(args.get("targets"))
+    if not targets:
+        return None
+    results: list[dict[str, object]] = []
+    for target in targets:
+        result = await whm_preflight_csf_entries(
+            session=session,
+            server_ref=server_ref,
+            target=target,
+        )
+        if isinstance(result, dict):
+            results.append(result)
+    return {"ok": True, "results": results}
+
+
+def collect_recent_preflight_evidence(
+    working_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    tool_calls_by_id: dict[str, dict[str, object]] = {}
+    evidence: list[dict[str, object]] = []
+
+    for message in _messages_since_last_user(working_messages):
+        parts = message.get("parts")
+        if not isinstance(parts, list):
+            continue
+        for raw_part in parts:
+            part = _coerce_part_record(raw_part)
+            if part is None:
+                continue
+
+            part_type = part.get("type")
+            tool_name = part.get("toolName")
+            if not isinstance(tool_name, str) or not tool_name.startswith(
+                "whm_preflight_"
+            ):
+                continue
+
+            tool_call_id = part.get("toolCallId")
+            if not isinstance(tool_call_id, str) or not tool_call_id:
+                continue
+
+            if part_type == "tool-call":
+                args = part.get("args")
+                args_obj = args if isinstance(args, dict) else {}
+                tool_calls_by_id[tool_call_id] = {
+                    "toolName": tool_name,
+                    "args": json_safe(args_obj),
+                }
+                continue
+
+            if part_type != "tool-result" or part.get("isError") is True:
+                continue
+
+            result = part.get("result")
+            if not isinstance(result, dict):
+                continue
+
+            call = tool_calls_by_id.get(tool_call_id, {})
+            entry: dict[str, object] = {
+                "toolName": tool_name,
+                "result": json_safe(result),
+            }
+            call_args = call.get("args")
+            if isinstance(call_args, dict):
+                entry["args"] = call_args
+            evidence.append(entry)
+
+    return evidence
+
+
+def collect_recent_preflight_results(
+    working_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "toolName": item["toolName"],
+            "result": item["result"],
+        }
+        for item in collect_recent_preflight_evidence(working_messages)
+    ]
+
+
+def _build_whm_account_lifecycle_workflow(
+    context: WorkflowTemplateContext,
+) -> list[WorkflowTodoItem]:
+    subject = _account_subject(context.tool_name, context.args)
+    action_label = _action_label(context.tool_name)
+    before_account = _matching_account_preflight(
+        preflight_evidence=context.preflight_evidence,
+        args=context.args,
+    )
+    after_account = _postflight_account(context.postflight_result)
+    reason = _normalized_text(context.args.get("reason"))
+
+    reason_step_status = "completed" if reason is not None else "pending"
+    approval_step_status = "pending"
+    execute_step_status = "pending"
+    postflight_step_status = "pending"
+    conclusion_step_status = "pending"
+
+    if context.phase == "waiting_on_user":
+        reason_step_status = "waiting_on_user"
+    elif context.phase == "waiting_on_approval":
+        approval_step_status = "waiting_on_approval"
+    elif context.phase == "executing":
+        approval_step_status = "completed"
+        execute_step_status = "in_progress"
+    elif context.phase == "completed":
+        approval_step_status = "completed"
+        execute_step_status = "completed"
+        postflight_step_status = "completed"
+        conclusion_step_status = "completed"
+    elif context.phase == "denied":
+        approval_step_status = "cancelled"
+        execute_step_status = "cancelled"
+        postflight_step_status = "cancelled"
+        conclusion_step_status = "completed"
+    elif context.phase == "failed":
+        approval_step_status = "completed"
+        execute_step_status = "cancelled"
+        postflight_step_status = "cancelled"
+        conclusion_step_status = "completed"
+
+    if reason is None and context.phase in {"completed", "denied", "failed"}:
+        reason_step_status = "cancelled"
+
+    return [
+        {
+            "content": _preflight_step_content(
+                subject=subject, before_account=before_account
+            ),
+            "status": "completed" if before_account is not None else "in_progress",
+            "priority": "high",
+        },
+        {
+            "content": _reason_step_content(action_label=action_label, reason=reason),
+            "status": cast(Any, reason_step_status),
+            "priority": "high",
+        },
+        {
+            "content": f"Request approval to {action_label} {subject}.",
+            "status": cast(Any, approval_step_status),
+            "priority": "high",
+        },
+        {
+            "content": f"Execute {action_label} for {subject}.",
+            "status": cast(Any, execute_step_status),
+            "priority": "high",
+        },
+        {
+            "content": _postflight_step_content(
+                tool_name=context.tool_name,
+                subject=subject,
+                after_account=after_account,
+                postflight_result=context.postflight_result,
+            ),
+            "status": cast(Any, postflight_step_status),
+            "priority": "high",
+        },
+        {
+            "content": _conclusion_step_content(
+                tool_name=context.tool_name,
+                subject=subject,
+                reason=reason,
+                before_account=before_account,
+                after_account=after_account,
+                result=context.result,
+                phase=context.phase,
+                error_code=context.error_code,
+            ),
+            "status": cast(Any, conclusion_step_status),
+            "priority": "high",
+        },
+    ]
+
+
+def _build_whm_account_contact_email_workflow(
+    context: WorkflowTemplateContext,
+) -> list[WorkflowTodoItem]:
+    subject = _account_subject(context.tool_name, context.args)
+    before_account = _matching_account_preflight(
+        preflight_evidence=context.preflight_evidence,
+        args=context.args,
+    )
+    after_account = _postflight_account(context.postflight_result)
+    reason = _normalized_text(context.args.get("reason"))
+    new_email = _normalized_text(context.args.get("new_email"))
+
+    statuses = _default_step_statuses(reason=reason, phase=context.phase)
+    return [
+        {
+            "content": _preflight_step_content(
+                subject=subject, before_account=before_account
+            ),
+            "status": "completed" if before_account is not None else "in_progress",
+            "priority": "high",
+        },
+        {
+            "content": _reason_step_content(
+                action_label="changing the contact email", reason=reason
+            ),
+            "status": cast(Any, statuses["reason"]),
+            "priority": "high",
+        },
+        {
+            "content": f"Request approval to change the contact email for {subject} to '{new_email or 'the requested value'}'.",
+            "status": cast(Any, statuses["approval"]),
+            "priority": "high",
+        },
+        {
+            "content": f"Execute the contact email change for {subject}.",
+            "status": cast(Any, statuses["execute"]),
+            "priority": "high",
+        },
+        {
+            "content": _contact_email_postflight_step_content(
+                subject=subject,
+                requested_email=new_email,
+                after_account=after_account,
+                postflight_result=context.postflight_result,
+            ),
+            "status": cast(Any, statuses["postflight"]),
+            "priority": "high",
+        },
+        {
+            "content": _contact_email_conclusion_step_content(
+                subject=subject,
+                reason=reason,
+                requested_email=new_email,
+                before_account=before_account,
+                after_account=after_account,
+                result=context.result,
+                phase=context.phase,
+                error_code=context.error_code,
+            ),
+            "status": cast(Any, statuses["conclusion"]),
+            "priority": "high",
+        },
+    ]
+
+
+def _build_whm_csf_batch_workflow(
+    context: WorkflowTemplateContext,
+) -> list[WorkflowTodoItem]:
+    targets = _normalized_string_list(context.args.get("targets"))
+    subject = _csf_subject(context.args)
+    reason = _normalized_text(context.args.get("reason"))
+    before_entries = _matching_csf_preflight_entries(
+        preflight_evidence=context.preflight_evidence,
+        args=context.args,
+    )
+    postflight_entries = _postflight_csf_entries(context.postflight_result)
+    statuses = _default_step_statuses(reason=reason, phase=context.phase)
+    preflight_complete = len(before_entries) == len(targets) and len(targets) > 0
+
+    return [
+        {
+            "content": _csf_preflight_step_content(
+                subject=subject, entries=before_entries, targets=targets
+            ),
+            "status": "completed" if preflight_complete else "in_progress",
+            "priority": "high",
+        },
+        {
+            "content": _reason_step_content(
+                action_label=_csf_action_phrase(context.tool_name), reason=reason
+            ),
+            "status": cast(Any, statuses["reason"]),
+            "priority": "high",
+        },
+        {
+            "content": f"Request approval to {_csf_action_phrase(context.tool_name)} for {subject}.",
+            "status": cast(Any, statuses["approval"]),
+            "priority": "high",
+        },
+        {
+            "content": f"Execute {_csf_action_phrase(context.tool_name)} for {subject}.",
+            "status": cast(Any, statuses["execute"]),
+            "priority": "high",
+        },
+        {
+            "content": _csf_postflight_step_content(
+                tool_name=context.tool_name,
+                subject=subject,
+                entries=postflight_entries,
+                postflight_result=context.postflight_result,
+            ),
+            "status": cast(Any, statuses["postflight"]),
+            "priority": "high",
+        },
+        {
+            "content": _csf_conclusion_step_content(
+                tool_name=context.tool_name,
+                subject=subject,
+                reason=reason,
+                before_entries=before_entries,
+                after_entries=postflight_entries,
+                result=context.result,
+                phase=context.phase,
+                error_code=context.error_code,
+            ),
+            "status": cast(Any, statuses["conclusion"]),
+            "priority": "high",
+        },
+    ]
+
+
+def _default_step_statuses(
+    *, reason: str | None, phase: WorkflowTemplatePhase
+) -> dict[str, str]:
+    statuses = {
+        "reason": "completed" if reason is not None else "pending",
+        "approval": "pending",
+        "execute": "pending",
+        "postflight": "pending",
+        "conclusion": "pending",
+    }
+    if phase == "waiting_on_user":
+        statuses["reason"] = "waiting_on_user"
+    elif phase == "waiting_on_approval":
+        statuses["approval"] = "waiting_on_approval"
+    elif phase == "executing":
+        statuses["approval"] = "completed"
+        statuses["execute"] = "in_progress"
+    elif phase == "completed":
+        statuses["approval"] = "completed"
+        statuses["execute"] = "completed"
+        statuses["postflight"] = "completed"
+        statuses["conclusion"] = "completed"
+    elif phase == "denied":
+        statuses["approval"] = "cancelled"
+        statuses["execute"] = "cancelled"
+        statuses["postflight"] = "cancelled"
+        statuses["conclusion"] = "completed"
+    elif phase == "failed":
+        statuses["approval"] = "completed"
+        statuses["execute"] = "cancelled"
+        statuses["postflight"] = "cancelled"
+        statuses["conclusion"] = "completed"
+    if reason is None and phase in {"completed", "denied", "failed"}:
+        statuses["reason"] = "cancelled"
+    return statuses
+
+
+def _account_subject(tool_name: str, args: dict[str, object]) -> str:
+    username = _normalized_text(args.get("username")) or "the account"
+    server_ref = _normalized_text(args.get("server_ref"))
+    if server_ref is None:
+        return f"'{username}'"
+    return f"'{username}' on '{server_ref}'"
+
+
+def _action_label(tool_name: str) -> str:
+    if tool_name == "whm_unsuspend_account":
+        return "unsuspend"
+    return "suspend"
+
+
+def _csf_action_phrase(tool_name: str) -> str:
+    mapping = {
+        "whm_csf_unblock": "remove CSF blocks",
+        "whm_csf_allowlist_remove": "remove CSF allowlist entries",
+        "whm_csf_allowlist_add_ttl": "add temporary CSF allowlist entries",
+        "whm_csf_denylist_add_ttl": "add temporary CSF denylist entries",
+    }
+    return mapping.get(tool_name, "apply the CSF change")
+
+
+def _preflight_step_content(
+    *, subject: str, before_account: dict[str, object] | None
+) -> str:
+    if before_account is None:
+        return f"Account lookup / preflight for {subject}."
+
+    state = _account_state(before_account)
+    details: list[str] = [f"state: {state}"]
+    domain = _normalized_text(before_account.get("domain"))
+    if domain is not None:
+        details.append(f"domain: {domain}")
+    contact = _normalized_text(before_account.get("contactemail"))
+    if contact is not None:
+        details.append(f"contact: {contact}")
+    suspend_reason = _normalized_text(before_account.get("suspendreason"))
+    if suspend_reason is not None:
+        details.append(f"suspend reason: {suspend_reason}")
+    return f"Account lookup / preflight for {subject}: {'; '.join(details)}."
+
+
+def _reason_step_content(*, action_label: str, reason: str | None) -> str:
+    if reason is None:
+        return f"Ask for reason if missing before {action_label}ing the account."
+    return f"Reason captured for the {action_label}: {reason}."
+
+
+def _contact_email_postflight_step_content(
+    *,
+    subject: str,
+    requested_email: str | None,
+    after_account: dict[str, object] | None,
+    postflight_result: dict[str, object] | None,
+) -> str:
+    if after_account is None:
+        if (
+            isinstance(postflight_result, dict)
+            and postflight_result.get("ok") is not True
+        ):
+            error_code = (
+                _normalized_text(postflight_result.get("error_code")) or "unknown"
+            )
+            return f"Postflight verification for {subject} could not confirm the contact email ({error_code})."
+        return f"Postflight verification for {subject}."
+    observed_email = _account_email(after_account) or "unknown"
+    return f"Postflight verification for {subject}: expected contact email '{requested_email or 'unknown'}', observed '{observed_email}'."
+
+
+def _contact_email_conclusion_step_content(
+    *,
+    subject: str,
+    reason: str | None,
+    requested_email: str | None,
+    before_account: dict[str, object] | None,
+    after_account: dict[str, object] | None,
+    result: dict[str, object] | None,
+    phase: WorkflowTemplatePhase,
+    error_code: str | None,
+) -> str:
+    before_email = _account_email(before_account) or "unknown"
+    after_email = _account_email(after_account) or before_email
+    reason_suffix = f" Reason: {reason}." if reason is not None else ""
+    if phase == "waiting_on_user":
+        return f"Conclusion with before/after contact email evidence for {subject} after the reason is provided."
+    if phase == "waiting_on_approval":
+        return f"Conclusion with before/after contact email evidence for {subject} after approval and execution.{reason_suffix}"
+    if phase == "executing":
+        return f"Conclusion for {subject} after execution and contact email verification.{reason_suffix}"
+    if phase == "denied":
+        return f"Conclusion: approval denied for {subject}; contact email stayed '{before_email}'.{reason_suffix}"
+    if phase == "failed":
+        return f"Conclusion: contact email change for {subject} did not complete successfully (error: {error_code or 'tool_execution_failed'}). Before email: '{before_email}'.{reason_suffix}"
+    result_status = (
+        _normalized_text(result.get("status")) if isinstance(result, dict) else None
+    )
+    if result_status == "no-op":
+        return f"Conclusion: no-op for {subject}. Contact email remained '{before_email}'.{reason_suffix}"
+    return f"Conclusion: contact email for {subject} moved from '{before_email}' to '{after_email}'.{reason_suffix}"
+
+
+def _csf_subject(args: dict[str, object]) -> str:
+    targets = _normalized_string_list(args.get("targets"))
+    server_ref = _normalized_text(args.get("server_ref")) or "the server"
+    if not targets:
+        return f"the requested targets on '{server_ref}'"
+    return f"{', '.join(repr(target) for target in targets)} on '{server_ref}'"
+
+
+def _csf_preflight_step_content(
+    *, subject: str, entries: list[dict[str, object]], targets: list[str]
+) -> str:
+    if not entries:
+        return f"Account lookup / preflight for {subject}."
+    seen_targets = {_normalized_text(entry.get("target")) for entry in entries}
+    summaries = [
+        f"{entry.get('target')}: {entry.get('verdict')}"
+        for entry in entries
+        if _normalized_text(entry.get("target")) is not None
+    ]
+    missing = [target for target in targets if target not in seen_targets]
+    if missing:
+        summaries.append("missing: " + ", ".join(missing))
+    return f"Account lookup / preflight for {subject}: {'; '.join(summaries)}."
+
+
+def _csf_postflight_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    entries: list[dict[str, object]],
+    postflight_result: dict[str, object] | None,
+) -> str:
+    if not entries:
+        if (
+            isinstance(postflight_result, dict)
+            and postflight_result.get("ok") is not True
+        ):
+            error_code = (
+                _normalized_text(postflight_result.get("error_code")) or "unknown"
+            )
+            return f"Postflight verification for {subject} could not be completed ({error_code})."
+        return f"Postflight verification for {subject}."
+    expectations = {
+        "whm_csf_unblock": "not blocked",
+        "whm_csf_allowlist_remove": "not allowlisted",
+        "whm_csf_allowlist_add_ttl": "allowlisted",
+        "whm_csf_denylist_add_ttl": "blocked",
+    }
+    expected = expectations.get(tool_name, "updated")
+    summaries = [
+        f"{entry.get('target')}: expected {expected}, observed {entry.get('verdict')}"
+        for entry in entries
+        if _normalized_text(entry.get("target")) is not None
+    ]
+    return f"Postflight verification for {subject}: {'; '.join(summaries)}."
+
+
+def _csf_conclusion_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    reason: str | None,
+    before_entries: list[dict[str, object]],
+    after_entries: list[dict[str, object]],
+    result: dict[str, object] | None,
+    phase: WorkflowTemplatePhase,
+    error_code: str | None,
+) -> str:
+    reason_suffix = f" Reason: {reason}." if reason is not None else ""
+    if phase == "waiting_on_user":
+        return f"Conclusion with before/after CSF evidence for {subject} after the reason is provided."
+    if phase == "waiting_on_approval":
+        return f"Conclusion with before/after CSF evidence for {subject} after approval and execution.{reason_suffix}"
+    if phase == "executing":
+        return f"Conclusion for {subject} after execution and CSF postflight verification.{reason_suffix}"
+    if phase == "denied":
+        return f"Conclusion: approval denied for {subject}; no CSF change executed.{reason_suffix}"
+    if phase == "failed":
+        return f"Conclusion: CSF change for {subject} did not complete successfully (error: {error_code or 'tool_execution_failed'}).{reason_suffix}"
+    result_items = _result_items(result)
+    changed = [
+        item.get("target") for item in result_items if item.get("status") == "changed"
+    ]
+    noop = [
+        item.get("target") for item in result_items if item.get("status") == "no-op"
+    ]
+    before_summary = _csf_entries_summary(before_entries)
+    after_summary = _csf_entries_summary(after_entries)
+    parts: list[str] = [f"Before: {before_summary}.", f"After: {after_summary}."]
+    if changed:
+        parts.append("Changed: " + ", ".join(str(item) for item in changed if item))
+    if noop:
+        parts.append("No-op: " + ", ".join(str(item) for item in noop if item))
+    return f"Conclusion for {subject}: {' '.join(parts)}{reason_suffix}"
+
+
+def _postflight_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    after_account: dict[str, object] | None,
+    postflight_result: dict[str, object] | None,
+) -> str:
+    if after_account is None:
+        if (
+            isinstance(postflight_result, dict)
+            and postflight_result.get("ok") is not True
+        ):
+            error_code = (
+                _normalized_text(postflight_result.get("error_code")) or "unknown"
+            )
+            return f"Postflight verification for {subject} could not be completed ({error_code})."
+        return f"Postflight verification for {subject}."
+
+    expected_state = "active" if tool_name == "whm_unsuspend_account" else "suspended"
+    actual_state = _account_state(after_account)
+    return f"Postflight verification for {subject}: expected {expected_state}, observed {actual_state}."
+
+
+def _conclusion_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    reason: str | None,
+    before_account: dict[str, object] | None,
+    after_account: dict[str, object] | None,
+    result: dict[str, object] | None,
+    phase: WorkflowTemplatePhase,
+    error_code: str | None,
+) -> str:
+    before_state = _account_state(before_account)
+    after_state = _account_state(after_account)
+    before_text = before_state or "unknown"
+    after_text = after_state or before_text
+    reason_suffix = f" Reason: {reason}." if reason is not None else ""
+
+    if phase == "waiting_on_user":
+        return f"Conclusion with before/after evidence for {subject} after the reason is provided."
+    if phase == "waiting_on_approval":
+        return f"Conclusion with before/after evidence for {subject} after approval and execution.{reason_suffix}"
+    if phase == "executing":
+        return f"Conclusion for {subject} after execution and postflight verification.{reason_suffix}"
+    if phase == "denied":
+        return f"Conclusion: approval denied for {subject}; no change executed. Before state remained {before_text}.{reason_suffix}"
+    if phase == "failed":
+        error_text = error_code or "tool_execution_failed"
+        return f"Conclusion: {subject} did not complete successfully (error: {error_text}). Before state: {before_text}.{reason_suffix}"
+
+    result_status = (
+        _normalized_text(result.get("status")) if isinstance(result, dict) else None
+    )
+    if result_status == "no-op":
+        return f"Conclusion: no-op for {subject}. Before state: {before_text}. After state: {after_text}.{reason_suffix}"
+    return f"Conclusion: {subject} moved from {before_text} to {after_text}.{reason_suffix}"
+
+
+def _matching_account_preflight(
+    *, preflight_evidence: list[dict[str, object]], args: dict[str, object]
+) -> dict[str, object] | None:
+    requested_server_ref = _normalized_text(args.get("server_ref"))
+    requested_username = _normalized_text(args.get("username"))
+    for item in preflight_evidence:
+        if item.get("toolName") != "whm_preflight_account":
+            continue
+        item_args = item.get("args")
+        result = item.get("result")
+        if not isinstance(item_args, dict) or not isinstance(result, dict):
+            continue
+        if result.get("ok") is not True:
+            continue
+        if _normalized_text(item_args.get("server_ref")) != requested_server_ref:
+            continue
+        account = result.get("account")
+        if not isinstance(account, dict):
+            continue
+        if _normalized_text(account.get("user")) != requested_username:
+            continue
+        return account
+    return None
+
+
+def _matching_csf_preflight_entries(
+    *, preflight_evidence: list[dict[str, object]], args: dict[str, object]
+) -> list[dict[str, object]]:
+    requested_server_ref = _normalized_text(args.get("server_ref"))
+    requested_targets = set(_normalized_string_list(args.get("targets")))
+    matches: list[dict[str, object]] = []
+    for item in preflight_evidence:
+        if item.get("toolName") != "whm_preflight_csf_entries":
+            continue
+        item_args = item.get("args")
+        result = item.get("result")
+        if not isinstance(item_args, dict) or not isinstance(result, dict):
+            continue
+        if result.get("ok") is not True:
+            continue
+        if _normalized_text(item_args.get("server_ref")) != requested_server_ref:
+            continue
+        target = _normalized_text(result.get("target"))
+        if target is None or target not in requested_targets:
+            continue
+        matches.append(result)
+    matches.sort(key=lambda entry: _normalized_text(entry.get("target")) or "")
+    return matches
+
+
+def _postflight_account(
+    postflight_result: dict[str, object] | None,
+) -> dict[str, object] | None:
+    if (
+        not isinstance(postflight_result, dict)
+        or postflight_result.get("ok") is not True
+    ):
+        return None
+    account = postflight_result.get("account")
+    if isinstance(account, dict):
+        return account
+    return None
+
+
+def _postflight_csf_entries(
+    postflight_result: dict[str, object] | None,
+) -> list[dict[str, object]]:
+    if not isinstance(postflight_result, dict):
+        return []
+    results = postflight_result.get("results")
+    if not isinstance(results, list):
+        return []
+    return [item for item in results if isinstance(item, dict)]
+
+
+def _account_state(account: dict[str, object] | None) -> str | None:
+    if not isinstance(account, dict):
+        return None
+    value = account.get("suspended")
+    if isinstance(value, bool):
+        return "suspended" if value else "active"
+    if isinstance(value, int):
+        return "suspended" if value == 1 else "active"
+    if isinstance(value, str):
+        return (
+            "suspended"
+            if value.strip().lower() in {"1", "true", "yes", "y"}
+            else "active"
+        )
+    return None
+
+
+def _account_email(account: dict[str, object] | None) -> str | None:
+    if not isinstance(account, dict):
+        return None
+    contact = _normalized_text(account.get("contactemail"))
+    if contact is not None:
+        return contact
+    return _normalized_text(account.get("email"))
+
+
+def _normalized_string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for item in value:
+        text = _normalized_text(item)
+        if text is not None:
+            normalized.append(text)
+    return normalized
+
+
+def _result_items(result: dict[str, object] | None) -> list[dict[str, object]]:
+    if not isinstance(result, dict):
+        return []
+    items = result.get("results")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _csf_entries_summary(entries: list[dict[str, object]]) -> str:
+    if not entries:
+        return "no evidence"
+    return "; ".join(
+        f"{entry.get('target')}={entry.get('verdict')}"
+        for entry in entries
+        if _normalized_text(entry.get("target")) is not None
+    )
+
+
+def _normalized_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _coerce_part_record(value: object) -> dict[str, object] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _messages_since_last_user(
+    working_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    last_user_index = -1
+    for index, message in enumerate(working_messages):
+        if message.get("role") == "user":
+            last_user_index = index
+    return working_messages[last_user_index + 1 :]

--- a/apps/api/tests/test_agent_runner.py
+++ b/apps/api/tests/test_agent_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import cast
 from uuid import UUID, uuid4
 
 from noa_api.core.agent.runner import (
@@ -851,6 +852,191 @@ async def test_agent_runner_rejects_change_tool_when_args_do_not_match_schema(
         "error_code": "invalid_tool_arguments",
         "details": ["Missing required field 'reason'"],
     }
+
+
+async def test_agent_runner_persists_deterministic_whm_workflow_when_reason_missing(
+    monkeypatch,
+) -> None:
+    from noa_api.core.tools.registry import get_tool_definition
+
+    repo = _InMemoryActionToolRunRepository(action_requests={}, tool_runs={})
+    captured: dict[str, object] = {}
+
+    async def _record_replace(self, *, thread_id, todos):
+        captured["thread_id"] = thread_id
+        captured["todos"] = todos
+
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.workflow_todos.WorkflowTodoService.replace_workflow",
+        _record_replace,
+    )
+
+    tool = get_tool_definition("whm_suspend_account")
+    assert tool is not None
+
+    class _SingleTurnLLM:
+        async def run_turn(
+            self,
+            *,
+            messages: list[dict[str, object]],
+            tools: list[dict[str, object]],
+            on_text_delta=None,
+        ) -> LLMTurnResponse:
+            _ = messages, tools, on_text_delta
+            return LLMTurnResponse(
+                text="",
+                tool_calls=[
+                    LLMToolCall(
+                        name="whm_suspend_account",
+                        arguments={"server_ref": "web1", "username": "alice"},
+                    )
+                ],
+            )
+
+    thread_id = uuid4()
+    runner = AgentRunner(
+        llm_client=_SingleTurnLLM(),
+        action_tool_run_service=ActionToolRunService(repository=repo),
+        session=cast(object, object()),
+    )
+
+    result = await runner.run_turn(
+        thread_messages=[
+            {"role": "user", "parts": [{"type": "text", "text": "Suspend alice"}]},
+            {
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "tool-call",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "args": {"server_ref": "web1", "username": "alice"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "parts": [
+                    {
+                        "type": "tool-result",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "result": {
+                            "ok": True,
+                            "account": {"user": "alice", "suspended": False},
+                        },
+                        "isError": False,
+                    }
+                ],
+            },
+        ],
+        available_tool_names={tool.name},
+        thread_id=thread_id,
+        requested_by_user_id=uuid4(),
+    )
+
+    assert repo.action_requests == {}
+    assert captured["thread_id"] == thread_id
+    todos = cast(list[dict[str, str]], captured["todos"])
+    assert len(todos) == 6
+    assert todos[0]["status"] == "completed"
+    assert todos[1]["status"] == "waiting_on_user"
+    assert todos[2]["status"] == "pending"
+
+    tool_message = next(
+        message for message in result.messages if message.role == "tool"
+    )
+    part = tool_message.parts[0]
+    assert isinstance(part, dict)
+    assert part["result"]["error_code"] == "invalid_tool_arguments"
+
+
+async def test_agent_runner_persists_deterministic_whm_workflow_while_waiting_for_approval(
+    monkeypatch,
+) -> None:
+    from noa_api.core.tools.registry import get_tool_definition
+
+    repo = _InMemoryActionToolRunRepository(action_requests={}, tool_runs={})
+    captured: dict[str, object] = {}
+
+    async def _record_replace(self, *, thread_id, todos):
+        captured["thread_id"] = thread_id
+        captured["todos"] = todos
+
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.workflow_todos.WorkflowTodoService.replace_workflow",
+        _record_replace,
+    )
+
+    tool = get_tool_definition("whm_suspend_account")
+    assert tool is not None
+
+    thread_id = uuid4()
+    runner = AgentRunner(
+        llm_client=_FakeLLMClient(
+            response=LLMTurnResponse(
+                text="",
+                tool_calls=[
+                    LLMToolCall(
+                        name="whm_suspend_account",
+                        arguments={
+                            "server_ref": "web1",
+                            "username": "alice",
+                            "reason": "billing hold",
+                        },
+                    )
+                ],
+            )
+        ),
+        action_tool_run_service=ActionToolRunService(repository=repo),
+        session=cast(object, object()),
+    )
+
+    result = await runner.run_turn(
+        thread_messages=[
+            {"role": "user", "parts": [{"type": "text", "text": "Suspend alice"}]},
+            {
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "tool-call",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "args": {"server_ref": "web1", "username": "alice"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "parts": [
+                    {
+                        "type": "tool-result",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "result": {
+                            "ok": True,
+                            "account": {"user": "alice", "suspended": False},
+                        },
+                        "isError": False,
+                    }
+                ],
+            },
+        ],
+        available_tool_names={tool.name},
+        thread_id=thread_id,
+        requested_by_user_id=uuid4(),
+    )
+
+    assert len(repo.action_requests) == 1
+    assert captured["thread_id"] == thread_id
+    todos = cast(list[dict[str, str]], captured["todos"])
+    assert len(todos) == 6
+    assert todos[0]["status"] == "completed"
+    assert todos[1]["status"] == "completed"
+    assert todos[2]["status"] == "waiting_on_approval"
+    approval_part = result.messages[-1].parts[0]
+    assert isinstance(approval_part, dict)
+    assert approval_part["toolName"] == "request_approval"
 
 
 async def test_agent_runner_rejects_whitespace_only_string_arguments(

--- a/apps/api/tests/test_assistant_service.py
+++ b/apps/api/tests/test_assistant_service.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import cast
 from uuid import UUID, uuid4
 
 import pytest
@@ -1432,6 +1433,163 @@ async def test_execute_approved_tool_run_allows_matching_server_id_preflight(
     assert repo.tool_runs[started.id].status == ToolRunStatus.COMPLETED
 
 
+async def test_execute_approved_tool_run_persists_completed_whm_workflow_with_evidence(
+    monkeypatch,
+) -> None:
+    from noa_api.api.assistant.assistant_action_operations import (
+        execute_approved_tool_run,
+    )
+
+    owner_id = uuid4()
+    thread_id = uuid4()
+    repo = _InMemoryActionToolRunRepository(action_requests={}, tool_runs={})
+    request = await repo.create_action_request(
+        thread_id=thread_id,
+        tool_name="whm_suspend_account",
+        args={
+            "server_ref": "web1",
+            "username": "alice",
+            "reason": "billing hold",
+        },
+        risk=ToolRisk.CHANGE,
+        requested_by_user_id=owner_id,
+    )
+    request.status = ActionRequestStatus.APPROVED
+    started = await repo.start_tool_run(
+        thread_id=thread_id,
+        tool_name=request.tool_name,
+        args=request.args,
+        action_request_id=request.id,
+        requested_by_user_id=owner_id,
+    )
+
+    async def successful_change(*, session, **kwargs):
+        _ = session, kwargs
+        return {"ok": True, "status": "changed", "message": "Account suspended"}
+
+    tool = ToolDefinition(
+        name="whm_suspend_account",
+        description="Suspends an account.",
+        risk=ToolRisk.CHANGE,
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "server_ref": {"type": "string"},
+                "username": {"type": "string"},
+                "reason": {"type": "string"},
+            },
+            "required": ["server_ref", "username", "reason"],
+            "additionalProperties": False,
+        },
+        result_schema={
+            "type": "object",
+            "properties": {
+                "ok": {"type": "boolean"},
+                "status": {"type": "string"},
+                "message": {"type": "string"},
+            },
+            "required": ["ok", "status", "message"],
+            "additionalProperties": False,
+        },
+        execute=successful_change,
+        workflow_family="whm-account-lifecycle",
+    )
+
+    monkeypatch.setattr(
+        "noa_api.api.assistant.assistant_action_operations.get_tool_definition",
+        lambda name: tool if name == tool.name else None,
+    )
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.action_tool_runs.get_tool_definition",
+        lambda name: tool if name == tool.name else None,
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _record_replace(self, *, thread_id, todos):
+        captured["thread_id"] = thread_id
+        captured["todos"] = todos
+
+    async def _postflight(**kwargs):
+        _ = kwargs
+        return {
+            "ok": True,
+            "account": {
+                "user": "alice",
+                "suspended": True,
+                "domain": "example.com",
+            },
+        }
+
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.workflow_todos.WorkflowTodoService.replace_workflow",
+        _record_replace,
+    )
+    monkeypatch.setattr(
+        "noa_api.api.assistant.assistant_action_operations.fetch_postflight_result",
+        _postflight,
+    )
+
+    assistant_repo = _FakeAssistantRepository(
+        listed_messages=[
+            SimpleNamespace(
+                role="user",
+                content=[{"type": "text", "text": "Suspend alice on web1."}],
+            ),
+            SimpleNamespace(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool-call",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "args": {"server_ref": "web1", "username": "alice"},
+                    }
+                ],
+            ),
+            SimpleNamespace(
+                role="tool",
+                content=[
+                    {
+                        "type": "tool-result",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "result": {
+                            "ok": True,
+                            "account": {
+                                "user": "alice",
+                                "suspended": False,
+                                "domain": "example.com",
+                            },
+                        },
+                        "isError": False,
+                    }
+                ],
+            ),
+        ]
+    )
+
+    await execute_approved_tool_run(
+        started_tool_run=started,
+        approved_request=request,
+        owner_user_id=owner_id,
+        owner_user_email="owner@example.com",
+        thread_id=thread_id,
+        repository=assistant_repo,
+        action_tool_run_service=ActionToolRunService(repository=repo),
+        session=_FakeSession(),
+    )
+
+    assert repo.tool_runs[started.id].status == ToolRunStatus.COMPLETED
+    assert captured["thread_id"] == thread_id
+    todos = cast(list[dict[str, str]], captured["todos"])
+    assert len(todos) == 6
+    assert todos[3]["status"] == "completed"
+    assert todos[4]["status"] == "completed"
+    assert todos[5]["status"] == "completed"
+    assert "moved from active to suspended" in todos[5]["content"]
+
+
 async def test_execute_approved_tool_run_rejects_mismatched_server_id_preflight(
     monkeypatch,
 ) -> None:
@@ -2596,6 +2754,432 @@ async def test_assistant_service_sanitizes_tool_result_messages_for_change_tools
     part = tool_message["parts"][0]
     assert part["type"] == "tool-result"
     assert part["result"]["when"] == "2026-03-13T12:00:00+00:00"
+
+
+async def test_deny_action_request_persists_denied_whm_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from noa_api.api.routes.assistant_action_operations import deny_action_request
+
+    owner_id = uuid4()
+    thread_id = uuid4()
+    repo = _InMemoryActionToolRunRepository(action_requests={}, tool_runs={})
+    request = await repo.create_action_request(
+        thread_id=thread_id,
+        tool_name="whm_change_contact_email",
+        args={
+            "server_ref": "web1",
+            "username": "alice",
+            "new_email": "new@example.com",
+            "reason": "customer request",
+        },
+        risk=ToolRisk.CHANGE,
+        requested_by_user_id=owner_id,
+    )
+    assistant_repo = _FakeAssistantRepository(
+        listed_messages=[
+            SimpleNamespace(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Change alice contact email on web1."}
+                ],
+            ),
+            SimpleNamespace(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool-call",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "args": {"server_ref": "web1", "username": "alice"},
+                    }
+                ],
+            ),
+            SimpleNamespace(
+                role="tool",
+                content=[
+                    {
+                        "type": "tool-result",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "result": {
+                            "ok": True,
+                            "account": {
+                                "user": "alice",
+                                "contactemail": "old@example.com",
+                            },
+                        },
+                        "isError": False,
+                    }
+                ],
+            ),
+        ]
+    )
+    captured: dict[str, object] = {}
+
+    async def _record_replace(self, *, thread_id, todos):
+        captured["thread_id"] = thread_id
+        captured["todos"] = todos
+
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.workflow_todos.WorkflowTodoService.replace_workflow",
+        _record_replace,
+    )
+
+    await deny_action_request(
+        owner_user_id=owner_id,
+        owner_user_email="owner@example.com",
+        thread_id=thread_id,
+        action_request_id=str(request.id),
+        repository=assistant_repo,
+        action_tool_run_service=ActionToolRunService(repository=repo),
+        session=_FakeSession(),
+    )
+
+    todos = cast(list[dict[str, str]], captured["todos"])
+    assert captured["thread_id"] == thread_id
+    assert todos[2]["status"] == "cancelled"
+    assert todos[5]["status"] == "completed"
+    assert "approval denied" in todos[5]["content"]
+
+
+async def test_execute_approved_tool_run_persists_completed_contact_email_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from noa_api.api.assistant.assistant_action_operations import (
+        execute_approved_tool_run,
+    )
+
+    owner_id = uuid4()
+    thread_id = uuid4()
+    repo = _InMemoryActionToolRunRepository(action_requests={}, tool_runs={})
+    request = await repo.create_action_request(
+        thread_id=thread_id,
+        tool_name="whm_change_contact_email",
+        args={
+            "server_ref": "web1",
+            "username": "alice",
+            "new_email": "new@example.com",
+            "reason": "customer request",
+        },
+        risk=ToolRisk.CHANGE,
+        requested_by_user_id=owner_id,
+    )
+    request.status = ActionRequestStatus.APPROVED
+    started = await repo.start_tool_run(
+        thread_id=thread_id,
+        tool_name=request.tool_name,
+        args=request.args,
+        action_request_id=request.id,
+        requested_by_user_id=owner_id,
+    )
+
+    async def successful_change(*, session, **kwargs):
+        _ = session, kwargs
+        return {"ok": True, "status": "changed", "message": "Contact email updated"}
+
+    tool = ToolDefinition(
+        name="whm_change_contact_email",
+        description="Updates contact email.",
+        risk=ToolRisk.CHANGE,
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "server_ref": {"type": "string"},
+                "username": {"type": "string"},
+                "new_email": {"type": "string"},
+                "reason": {"type": "string"},
+            },
+            "required": ["server_ref", "username", "new_email", "reason"],
+            "additionalProperties": False,
+        },
+        result_schema={
+            "type": "object",
+            "properties": {
+                "ok": {"type": "boolean"},
+                "status": {"type": "string"},
+                "message": {"type": "string"},
+            },
+            "required": ["ok", "status", "message"],
+            "additionalProperties": False,
+        },
+        execute=successful_change,
+        workflow_family="whm-account-contact-email",
+    )
+
+    monkeypatch.setattr(
+        "noa_api.api.assistant.assistant_action_operations.get_tool_definition",
+        lambda name: tool if name == tool.name else None,
+    )
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.action_tool_runs.get_tool_definition",
+        lambda name: tool if name == tool.name else None,
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _record_replace(self, *, thread_id, todos):
+        captured["thread_id"] = thread_id
+        captured["todos"] = todos
+
+    async def _postflight(**kwargs):
+        _ = kwargs
+        return {
+            "ok": True,
+            "account": {"user": "alice", "contactemail": "new@example.com"},
+        }
+
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.workflow_todos.WorkflowTodoService.replace_workflow",
+        _record_replace,
+    )
+    monkeypatch.setattr(
+        "noa_api.api.assistant.assistant_action_operations.fetch_postflight_result",
+        _postflight,
+    )
+
+    assistant_repo = _FakeAssistantRepository(
+        listed_messages=[
+            SimpleNamespace(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Change alice contact email on web1."}
+                ],
+            ),
+            SimpleNamespace(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool-call",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "args": {"server_ref": "web1", "username": "alice"},
+                    }
+                ],
+            ),
+            SimpleNamespace(
+                role="tool",
+                content=[
+                    {
+                        "type": "tool-result",
+                        "toolName": "whm_preflight_account",
+                        "toolCallId": "preflight-1",
+                        "result": {
+                            "ok": True,
+                            "account": {
+                                "user": "alice",
+                                "contactemail": "old@example.com",
+                            },
+                        },
+                        "isError": False,
+                    }
+                ],
+            ),
+        ]
+    )
+
+    await execute_approved_tool_run(
+        started_tool_run=started,
+        approved_request=request,
+        owner_user_id=owner_id,
+        owner_user_email="owner@example.com",
+        thread_id=thread_id,
+        repository=assistant_repo,
+        action_tool_run_service=ActionToolRunService(repository=repo),
+        session=_FakeSession(),
+    )
+
+    todos = cast(list[dict[str, str]], captured["todos"])
+    assert captured["thread_id"] == thread_id
+    assert todos[4]["status"] == "completed"
+    assert "expected contact email 'new@example.com'" in todos[4]["content"]
+    assert "moved from 'old@example.com' to 'new@example.com'" in todos[5]["content"]
+
+
+async def test_execute_approved_tool_run_persists_completed_csf_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from noa_api.api.assistant.assistant_action_operations import (
+        execute_approved_tool_run,
+    )
+
+    owner_id = uuid4()
+    thread_id = uuid4()
+    repo = _InMemoryActionToolRunRepository(action_requests={}, tool_runs={})
+    request = await repo.create_action_request(
+        thread_id=thread_id,
+        tool_name="whm_csf_unblock",
+        args={
+            "server_ref": "web1",
+            "targets": ["1.2.3.4", "5.6.7.8"],
+            "reason": "customer request",
+        },
+        risk=ToolRisk.CHANGE,
+        requested_by_user_id=owner_id,
+    )
+    request.status = ActionRequestStatus.APPROVED
+    started = await repo.start_tool_run(
+        thread_id=thread_id,
+        tool_name=request.tool_name,
+        args=request.args,
+        action_request_id=request.id,
+        requested_by_user_id=owner_id,
+    )
+
+    async def successful_change(*, session, **kwargs):
+        _ = session, kwargs
+        return {
+            "ok": True,
+            "results": [
+                {
+                    "target": "1.2.3.4",
+                    "ok": True,
+                    "status": "changed",
+                    "verdict": "clear",
+                    "matches": [],
+                },
+                {
+                    "target": "5.6.7.8",
+                    "ok": True,
+                    "status": "no-op",
+                    "verdict": "clear",
+                    "matches": [],
+                },
+            ],
+        }
+
+    tool = ToolDefinition(
+        name="whm_csf_unblock",
+        description="Unblocks CSF targets.",
+        risk=ToolRisk.CHANGE,
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "server_ref": {"type": "string"},
+                "targets": {"type": "array", "items": {"type": "string"}},
+                "reason": {"type": "string"},
+            },
+            "required": ["server_ref", "targets", "reason"],
+            "additionalProperties": False,
+        },
+        result_schema={
+            "type": "object",
+            "properties": {"ok": {"type": "boolean"}, "results": {"type": "array"}},
+            "required": ["ok", "results"],
+            "additionalProperties": False,
+        },
+        execute=successful_change,
+        workflow_family="whm-csf-batch-change",
+    )
+
+    monkeypatch.setattr(
+        "noa_api.api.assistant.assistant_action_operations.get_tool_definition",
+        lambda name: tool if name == tool.name else None,
+    )
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.action_tool_runs.get_tool_definition",
+        lambda name: tool if name == tool.name else None,
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _record_replace(self, *, thread_id, todos):
+        captured["thread_id"] = thread_id
+        captured["todos"] = todos
+
+    async def _postflight(**kwargs):
+        _ = kwargs
+        return {
+            "ok": True,
+            "results": [
+                {"ok": True, "target": "1.2.3.4", "verdict": "clear", "matches": []},
+                {"ok": True, "target": "5.6.7.8", "verdict": "clear", "matches": []},
+            ],
+        }
+
+    monkeypatch.setattr(
+        "noa_api.storage.postgres.workflow_todos.WorkflowTodoService.replace_workflow",
+        _record_replace,
+    )
+    monkeypatch.setattr(
+        "noa_api.api.assistant.assistant_action_operations.fetch_postflight_result",
+        _postflight,
+    )
+
+    assistant_repo = _FakeAssistantRepository(
+        listed_messages=[
+            SimpleNamespace(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Unblock 1.2.3.4 and 5.6.7.8 on web1."}
+                ],
+            ),
+            SimpleNamespace(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool-call",
+                        "toolName": "whm_preflight_csf_entries",
+                        "toolCallId": "preflight-1",
+                        "args": {"server_ref": "web1", "target": "1.2.3.4"},
+                    },
+                    {
+                        "type": "tool-call",
+                        "toolName": "whm_preflight_csf_entries",
+                        "toolCallId": "preflight-2",
+                        "args": {"server_ref": "web1", "target": "5.6.7.8"},
+                    },
+                ],
+            ),
+            SimpleNamespace(
+                role="tool",
+                content=[
+                    {
+                        "type": "tool-result",
+                        "toolName": "whm_preflight_csf_entries",
+                        "toolCallId": "preflight-1",
+                        "result": {
+                            "ok": True,
+                            "target": "1.2.3.4",
+                            "verdict": "blocked",
+                            "matches": ["deny"],
+                        },
+                        "isError": False,
+                    },
+                    {
+                        "type": "tool-result",
+                        "toolName": "whm_preflight_csf_entries",
+                        "toolCallId": "preflight-2",
+                        "result": {
+                            "ok": True,
+                            "target": "5.6.7.8",
+                            "verdict": "clear",
+                            "matches": [],
+                        },
+                        "isError": False,
+                    },
+                ],
+            ),
+        ]
+    )
+
+    await execute_approved_tool_run(
+        started_tool_run=started,
+        approved_request=request,
+        owner_user_id=owner_id,
+        owner_user_email="owner@example.com",
+        thread_id=thread_id,
+        repository=assistant_repo,
+        action_tool_run_service=ActionToolRunService(repository=repo),
+        session=_FakeSession(),
+    )
+
+    todos = cast(list[dict[str, str]], captured["todos"])
+    assert captured["thread_id"] == thread_id
+    assert todos[4]["status"] == "completed"
+    assert "1.2.3.4: expected not blocked, observed clear" in todos[4]["content"]
+    assert "Changed: 1.2.3.4" in todos[5]["content"]
+    assert "No-op: 5.6.7.8" in todos[5]["content"]
 
 
 async def _allow() -> bool:

--- a/apps/api/tests/test_tools_registry.py
+++ b/apps/api/tests/test_tools_registry.py
@@ -97,6 +97,23 @@ async def test_openai_tool_schema_includes_risk_notes_and_guidance() -> None:
     assert "Keep exactly one item in_progress at a time" in todo_description
 
 
+async def test_whm_change_tools_expose_workflow_families() -> None:
+    by_name = {tool.name: tool for tool in get_tool_registry()}
+
+    assert by_name["whm_suspend_account"].workflow_family == "whm-account-lifecycle"
+    assert by_name["whm_unsuspend_account"].workflow_family == "whm-account-lifecycle"
+    assert (
+        by_name["whm_change_contact_email"].workflow_family
+        == "whm-account-contact-email"
+    )
+    assert by_name["whm_csf_unblock"].workflow_family == "whm-csf-batch-change"
+    assert by_name["whm_csf_allowlist_remove"].workflow_family == "whm-csf-batch-change"
+    assert (
+        by_name["whm_csf_allowlist_add_ttl"].workflow_family == "whm-csf-batch-change"
+    )
+    assert by_name["whm_csf_denylist_add_ttl"].workflow_family == "whm-csf-batch-change"
+
+
 async def test_tools_catalog_is_sourced_live_from_registry(monkeypatch) -> None:
     monkeypatch.setattr(catalog, "get_tool_names", lambda: ("dynamic_tool",))
 


### PR DESCRIPTION
Fixes #4
Refs #10

## Summary
- add a reusable API workflow template registry and use it to drive canonical WHM workflow state instead of generic single-step todos
- cover all WHM change tools, including suspend/unsuspend, contact email changes, CSF batch changes, and denied/executing/completed workflow transitions
- add regression tests for workflow family registration and persisted workflow behavior across runner, approval, and execution paths

## Testing
- uv run pytest -q tests/test_workflow_todo_tool.py tests/test_agent_runner.py tests/test_assistant_service.py tests/test_tools_registry.py tests/test_tool_result_validation.py