### PR TITLE
fix(api): generalize workflow template orchestration

### DIFF
--- a/apps/api/src/noa_api/core/agent/runner.py
+++ b/apps/api/src/noa_api/core/agent/runner.py
@@ -22,10 +22,13 @@ from noa_api.core.tools.registry import (
     get_tool_registry,
 )
 from noa_api.core.workflows.registry import (
+    build_approval_context,
     build_workflow_todos,
     collect_recent_preflight_evidence,
-    collect_recent_preflight_results,
+    describe_workflow_activity,
+    infer_waiting_on_user_workflow_from_messages,
     persist_workflow_todos,
+    require_matching_preflight,
 )
 from noa_api.storage.postgres.action_tool_runs import ActionToolRunService
 from noa_api.storage.postgres.lifecycle import ToolRisk
@@ -760,7 +763,10 @@ class AgentRunner:
         if not _assistant_is_requesting_reason(assistant_text):
             return
 
-        inferred = _infer_waiting_on_user_workflow_from_messages(working_messages)
+        inferred = _infer_waiting_on_user_workflow_from_messages(
+            working_messages,
+            assistant_text=assistant_text,
+        )
         if inferred is None:
             return
 
@@ -921,27 +927,6 @@ def _safe_json_object(raw: str | None) -> dict[str, object]:
     return {}
 
 
-def _humanize_tool_name(tool_name: str) -> str:
-    return (
-        " ".join(part.capitalize() for part in tool_name.split("_") if part.strip())
-        or "Tool"
-    )
-
-
-def _coerce_part_record(value: object) -> dict[str, object] | None:
-    return value if isinstance(value, dict) else None
-
-
-def _messages_since_last_user(
-    working_messages: list[dict[str, object]],
-) -> list[dict[str, object]]:
-    last_user_index = -1
-    for index, message in enumerate(working_messages):
-        if message.get("role") == "user":
-            last_user_index = index
-    return working_messages[last_user_index + 1 :]
-
-
 def _require_matching_preflight(
     *,
     tool_name: str,
@@ -949,143 +934,11 @@ def _require_matching_preflight(
     working_messages: list[dict[str, object]],
     requested_server_id: str | None = None,
 ) -> SanitizedToolError | None:
-    if tool_name in {
-        "whm_suspend_account",
-        "whm_unsuspend_account",
-        "whm_change_contact_email",
-    }:
-        return _require_account_preflight(
-            args=args,
-            working_messages=working_messages,
-            requested_server_id=requested_server_id,
-        )
-
-    if tool_name in {
-        "whm_csf_unblock",
-        "whm_csf_allowlist_remove",
-        "whm_csf_allowlist_add_ttl",
-        "whm_csf_denylist_add_ttl",
-    }:
-        return _require_csf_preflight(
-            args=args,
-            working_messages=working_messages,
-            requested_server_id=requested_server_id,
-        )
-
-    return None
-
-
-def _require_account_preflight(
-    *,
-    args: dict[str, object],
-    working_messages: list[dict[str, object]],
-    requested_server_id: str | None,
-) -> SanitizedToolError | None:
-    requested_server_ref = _normalized_text(args.get("server_ref"))
-    requested_username = _normalized_text(args.get("username"))
-    if requested_server_ref is None or requested_username is None:
-        return None
-
-    evidence = [
-        item
-        for item in collect_recent_preflight_evidence(working_messages)
-        if item.get("toolName") == "whm_preflight_account"
-        and isinstance(item.get("result"), dict)
-        and cast(dict[str, object], item["result"]).get("ok") is True
-    ]
-    if not evidence:
-        return SanitizedToolError(
-            error="Required WHM preflight evidence is missing",
-            error_code="preflight_required",
-            details=(
-                "Run whm_preflight_account with the same server_ref and username before requesting this change.",
-            ),
-        )
-
-    for item in evidence:
-        item_args = item.get("args")
-        result = item.get("result")
-        if not isinstance(item_args, dict) or not isinstance(result, dict):
-            continue
-        if not _server_identity_matches(
-            item_args=item_args,
-            result=result,
-            requested_server_ref=requested_server_ref,
-            requested_server_id=requested_server_id,
-        ):
-            continue
-        account = result.get("account")
-        if not isinstance(account, dict):
-            continue
-        if _normalized_text(account.get("user")) == requested_username:
-            return None
-
-    return SanitizedToolError(
-        error="Required WHM preflight evidence does not match this change request",
-        error_code="preflight_mismatch",
-        details=(
-            f"No successful whm_preflight_account was found for server_ref '{requested_server_ref}' and username '{requested_username}' in the current turn.",
-        ),
-    )
-
-
-def _require_csf_preflight(
-    *,
-    args: dict[str, object],
-    working_messages: list[dict[str, object]],
-    requested_server_id: str | None,
-) -> SanitizedToolError | None:
-    requested_server_ref = _normalized_text(args.get("server_ref"))
-    requested_targets = _normalized_string_list(args.get("targets"))
-    if requested_server_ref is None or not requested_targets:
-        return None
-
-    evidence = [
-        item
-        for item in collect_recent_preflight_evidence(working_messages)
-        if item.get("toolName") == "whm_preflight_csf_entries"
-        and isinstance(item.get("result"), dict)
-        and cast(dict[str, object], item["result"]).get("ok") is True
-    ]
-    if not evidence:
-        return SanitizedToolError(
-            error="Required WHM preflight evidence is missing",
-            error_code="preflight_required",
-            details=(
-                "Run whm_preflight_csf_entries for each target with the same server_ref before requesting this change.",
-            ),
-        )
-
-    matched_targets: set[str] = set()
-    for item in evidence:
-        item_args = item.get("args")
-        result = item.get("result")
-        if not isinstance(item_args, dict) or not isinstance(result, dict):
-            continue
-        if not _server_identity_matches(
-            item_args=item_args,
-            result=result,
-            requested_server_ref=requested_server_ref,
-            requested_server_id=requested_server_id,
-        ):
-            continue
-        target = _normalized_text(result.get("target"))
-        if target is not None:
-            matched_targets.add(target)
-
-    missing_targets = [
-        target for target in requested_targets if target not in matched_targets
-    ]
-    if not missing_targets:
-        return None
-
-    return SanitizedToolError(
-        error="Required WHM preflight evidence does not match this change request",
-        error_code="preflight_mismatch",
-        details=(
-            "Missing successful whm_preflight_csf_entries results for target(s): "
-            + ", ".join(f"'{target}'" for target in missing_targets),
-        ),
+    return require_matching_preflight(
+        tool_name=tool_name,
+        args=args,
+        working_messages=working_messages,
+        requested_server_id=requested_server_id,
     )
 
 
@@ -1094,17 +947,6 @@ def _normalized_text(value: object) -> str | None:
         return None
     normalized = value.strip()
     return normalized or None
-
-
-def _normalized_string_list(value: object) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    normalized: list[str] = []
-    for item in value:
-        text = _normalized_text(item)
-        if text is not None:
-            normalized.append(text)
-    return normalized
 
 
 async def _resolve_requested_server_id(
@@ -1123,139 +965,17 @@ async def _resolve_requested_server_id(
     return str(resolution.server_id)
 
 
-def _server_identity_matches(
-    *,
-    item_args: dict[str, object],
-    result: dict[str, object],
-    requested_server_ref: str,
-    requested_server_id: str | None,
-) -> bool:
-    result_server_id = _normalized_text(result.get("server_id"))
-    if requested_server_id is not None and result_server_id is not None:
-        return result_server_id == requested_server_id
-    return _normalized_text(item_args.get("server_ref")) == requested_server_ref
-
-
-def _format_argument_value(value: object) -> str:
-    if isinstance(value, bool):
-        return "yes" if value else "no"
-    if isinstance(value, (int, float)):
-        return str(value)
-    if isinstance(value, str):
-        return value
-    if value is None:
-        return "none"
-    if isinstance(value, list):
-        return ", ".join(_format_argument_value(item) for item in value[:5])
-    return json.dumps(json_safe(value))
-
-
-def _summarize_arguments(args: dict[str, object]) -> list[dict[str, str]]:
-    hidden_keys = {"api_token", "password", "secret", "token"}
-    items: list[dict[str, str]] = []
-    for key, value in args.items():
-        if key in hidden_keys:
-            continue
-        items.append(
-            {
-                "label": key.replace("_", " ").capitalize(),
-                "value": _format_argument_value(value),
-            }
-        )
-    return items
-
-
-def _describe_activity(tool_name: str, args: dict[str, object]) -> str:
-    if tool_name == "whm_unsuspend_account":
-        return f"Unsuspend account '{args.get('username', 'unknown')}'"
-    if tool_name == "whm_suspend_account":
-        return f"Suspend account '{args.get('username', 'unknown')}'"
-    if tool_name == "whm_change_contact_email":
-        return (
-            f"Change contact email for '{args.get('username', 'unknown')}' "
-            f"to '{args.get('new_email', 'unknown')}'"
-        )
-    if tool_name == "whm_csf_unblock":
-        return f"Remove CSF block for '{_format_argument_value(args.get('targets'))}'"
-    if tool_name == "whm_csf_allowlist_add_ttl":
-        return (
-            f"Add '{_format_argument_value(args.get('targets'))}' to the CSF allowlist"
-        )
-    if tool_name == "whm_csf_allowlist_remove":
-        return f"Remove '{_format_argument_value(args.get('targets'))}' from the CSF allowlist"
-    if tool_name == "whm_csf_denylist_add_ttl":
-        return (
-            f"Add '{_format_argument_value(args.get('targets'))}' to the CSF denylist"
-        )
-    return _humanize_tool_name(tool_name)
-
-
-def _extract_before_state(
-    preflight_results: list[dict[str, object]],
-) -> list[dict[str, str]]:
-    before_state: list[dict[str, str]] = []
-    for item in preflight_results:
-        tool_name = item.get("toolName")
-        result = item.get("result")
-        if not isinstance(tool_name, str) or not isinstance(result, dict):
-            continue
-        if tool_name == "whm_preflight_account":
-            account = result.get("account")
-            if isinstance(account, dict):
-                for key, label in (
-                    ("user", "Username"),
-                    ("domain", "Domain"),
-                    ("contactemail", "Contact email"),
-                    ("suspended", "Suspended"),
-                    ("suspendreason", "Suspend reason"),
-                    ("plan", "Plan"),
-                ):
-                    value = account.get(key)
-                    if value in (None, ""):
-                        continue
-                    before_state.append(
-                        {"label": label, "value": _format_argument_value(value)}
-                    )
-        if tool_name == "whm_preflight_csf_entries":
-            verdict = result.get("verdict")
-            target = result.get("target")
-            if target not in (None, ""):
-                before_state.append(
-                    {"label": "Target", "value": _format_argument_value(target)}
-                )
-            if verdict not in (None, ""):
-                before_state.append(
-                    {
-                        "label": "Current CSF state",
-                        "value": _format_argument_value(verdict),
-                    }
-                )
-            matches = result.get("matches")
-            if isinstance(matches, list) and matches:
-                before_state.append(
-                    {
-                        "label": "Matched entries",
-                        "value": "; ".join(
-                            _format_argument_value(match) for match in matches[:3]
-                        ),
-                    }
-                )
-    return before_state
-
-
 def _build_approval_context(
     *,
     tool_name: str,
     args: dict[str, object],
     working_messages: list[dict[str, object]],
 ) -> dict[str, object]:
-    preflight_results = collect_recent_preflight_results(working_messages)
-    return {
-        "activity": _describe_activity(tool_name, args),
-        "argumentSummary": _summarize_arguments(args),
-        "beforeState": _extract_before_state(preflight_results),
-        "preflightResults": preflight_results,
-    }
+    return build_approval_context(
+        tool_name=tool_name,
+        args=args,
+        working_messages=working_messages,
+    )
 
 
 def _to_openai_tool_schema(tool: ToolDefinition) -> dict[str, object]:
@@ -1328,7 +1048,7 @@ def _assistant_guidance_for_change_validation_error(
     if not any("reason" in detail for detail in details):
         return None
 
-    activity = _describe_activity(tool_name, args).lower()
+    activity = describe_workflow_activity(tool_name=tool_name, args=args).lower()
     return (
         f"I need a short, human-readable reason before I can continue {activity}. "
         "Please provide the reason you want recorded for this change."
@@ -1363,92 +1083,18 @@ def _assistant_is_requesting_reason(text: str) -> bool:
 
 
 def _infer_waiting_on_user_workflow_from_messages(
-    working_messages: list[dict[str, object]],
+    working_messages: list[dict[str, object]], assistant_text: str | None = None
 ) -> dict[str, object] | None:
-    last_user_text = _latest_user_text(working_messages)
-    if last_user_text is None:
-        return None
-
-    tool_name = _infer_whm_account_lifecycle_tool_name(last_user_text)
-    if tool_name is None:
-        return None
-
-    evidence = collect_recent_preflight_evidence(working_messages)
-    account_candidates = [
-        item
-        for item in evidence
-        if item.get("toolName") == "whm_preflight_account"
-        and isinstance(item.get("args"), dict)
-    ]
-    if not account_candidates:
-        return None
-
-    match = _select_account_preflight_candidate(
-        account_candidates=account_candidates,
-        user_text=last_user_text,
+    inferred = infer_waiting_on_user_workflow_from_messages(
+        assistant_text=assistant_text or "",
+        working_messages=working_messages,
     )
-    if match is None:
+    if inferred is None:
         return None
-
-    args = cast(dict[str, object], match.get("args"))
-    server_ref = _normalized_text(args.get("server_ref"))
-    username = _normalized_text(args.get("username"))
-    if server_ref is None or username is None:
-        return None
-
     return {
-        "tool_name": tool_name,
-        "args": {
-            "server_ref": server_ref,
-            "username": username,
-        },
+        "tool_name": inferred.tool_name,
+        "args": inferred.args,
     }
-
-
-def _latest_user_text(working_messages: list[dict[str, object]]) -> str | None:
-    for message in reversed(working_messages):
-        if message.get("role") != "user":
-            continue
-        parts = message.get("parts")
-        if not isinstance(parts, list):
-            continue
-        for part in parts:
-            if not isinstance(part, dict) or part.get("type") != "text":
-                continue
-            text = part.get("text")
-            if isinstance(text, str) and text.strip():
-                return text.strip()
-    return None
-
-
-def _infer_whm_account_lifecycle_tool_name(user_text: str) -> str | None:
-    lowered = user_text.lower()
-    if "unsuspend" in lowered:
-        return "whm_unsuspend_account"
-    if "suspend" in lowered:
-        return "whm_suspend_account"
-    return None
-
-
-def _select_account_preflight_candidate(
-    *, account_candidates: list[dict[str, object]], user_text: str
-) -> dict[str, object] | None:
-    if len(account_candidates) == 1:
-        return account_candidates[0]
-
-    lowered = user_text.lower()
-    for candidate in reversed(account_candidates):
-        args = candidate.get("args")
-        if not isinstance(args, dict):
-            continue
-        server_ref = _normalized_text(args.get("server_ref"))
-        username = _normalized_text(args.get("username"))
-        if server_ref is None or username is None:
-            continue
-        if server_ref.lower() in lowered and username.lower() in lowered:
-            return candidate
-
-    return None
 
 
 def _split_text_deltas(text: str, *, chunk_size: int = 24) -> list[str]:

--- a/apps/api/src/noa_api/core/workflows/registry.py
+++ b/apps/api/src/noa_api/core/workflows/registry.py
@@ -1,42 +1,51 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Literal, cast
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from noa_api.core.json_safety import json_safe
 from noa_api.core.tools.registry import get_tool_definition
+from noa_api.core.workflows.types import (
+    WorkflowInference,
+    WorkflowTemplate,
+    WorkflowTemplateContext,
+    collect_recent_preflight_evidence,
+    collect_recent_preflight_results,
+)
+from noa_api.core.workflows.whm import WORKFLOW_TEMPLATES as WHM_WORKFLOW_TEMPLATES
 from noa_api.storage.postgres.workflow_todos import (
     SQLWorkflowTodoRepository,
     WorkflowTodoItem,
     WorkflowTodoService,
 )
-from noa_api.whm.tools.preflight_tools import (
-    whm_preflight_account,
-    whm_preflight_csf_entries,
-)
 
-WorkflowTemplatePhase = Literal[
-    "waiting_on_user",
-    "waiting_on_approval",
-    "executing",
-    "completed",
-    "denied",
-    "failed",
+_WORKFLOW_TEMPLATES: dict[str, WorkflowTemplate] = {}
+
+__all__ = [
+    "build_approval_context",
+    "build_workflow_todos",
+    "collect_recent_preflight_evidence",
+    "collect_recent_preflight_results",
+    "describe_workflow_activity",
+    "fetch_postflight_result",
+    "get_workflow_family",
+    "get_workflow_template",
+    "infer_waiting_on_user_workflow_from_messages",
+    "list_registered_workflow_families",
+    "persist_workflow_todos",
+    "register_workflow_template",
+    "require_matching_preflight",
 ]
 
 
-@dataclass(frozen=True, slots=True)
-class WorkflowTemplateContext:
-    tool_name: str
-    args: dict[str, object]
-    phase: WorkflowTemplatePhase
-    preflight_evidence: list[dict[str, object]]
-    result: dict[str, object] | None = None
-    postflight_result: dict[str, object] | None = None
-    error_code: str | None = None
+def register_workflow_template(*, family: str, template: WorkflowTemplate) -> None:
+    if family in _WORKFLOW_TEMPLATES:
+        raise ValueError(f"Workflow template already registered for family '{family}'")
+    _WORKFLOW_TEMPLATES[family] = template
+
+
+def list_registered_workflow_families() -> tuple[str, ...]:
+    return tuple(sorted(_WORKFLOW_TEMPLATES))
 
 
 def get_workflow_family(
@@ -50,34 +59,40 @@ def get_workflow_family(
     return tool.workflow_family
 
 
+def get_workflow_template(
+    tool_name: str, *, workflow_family: str | None = None
+) -> WorkflowTemplate | None:
+    family = get_workflow_family(tool_name, workflow_family=workflow_family)
+    if family is None:
+        return None
+    return _WORKFLOW_TEMPLATES.get(family)
+
+
 def build_workflow_todos(
     *,
     tool_name: str,
     workflow_family: str | None = None,
     args: dict[str, object],
-    phase: WorkflowTemplatePhase,
+    phase: str,
     preflight_evidence: list[dict[str, object]],
     result: dict[str, object] | None = None,
     postflight_result: dict[str, object] | None = None,
     error_code: str | None = None,
 ) -> list[WorkflowTodoItem] | None:
-    family = get_workflow_family(tool_name, workflow_family=workflow_family)
+    template = get_workflow_template(tool_name, workflow_family=workflow_family)
+    if template is None:
+        return None
+
     context = WorkflowTemplateContext(
         tool_name=tool_name,
         args=args,
-        phase=phase,
+        phase=phase,  # type: ignore[arg-type]
         preflight_evidence=preflight_evidence,
         result=result,
         postflight_result=postflight_result,
         error_code=error_code,
     )
-    if family == "whm-account-lifecycle":
-        return _build_whm_account_lifecycle_workflow(context)
-    if family == "whm-account-contact-email":
-        return _build_whm_account_contact_email_workflow(context)
-    if family == "whm-csf-batch-change":
-        return _build_whm_csf_batch_workflow(context)
-    return None
+    return template.build_todos(context)
 
 
 async def persist_workflow_todos(
@@ -103,779 +118,128 @@ async def fetch_postflight_result(
 ) -> dict[str, object] | None:
     if session is None:
         return None
-    if get_workflow_family(tool_name, workflow_family=workflow_family) not in {
-        "whm-account-lifecycle",
-        "whm-account-contact-email",
-        "whm-csf-batch-change",
-    }:
+    template = get_workflow_template(tool_name, workflow_family=workflow_family)
+    if template is None:
         return None
-
-    family = get_workflow_family(tool_name, workflow_family=workflow_family)
-
-    server_ref = _normalized_text(args.get("server_ref"))
-    if server_ref is None:
-        return None
-    if family in {"whm-account-lifecycle", "whm-account-contact-email"}:
-        username = _normalized_text(args.get("username"))
-        if username is None:
-            return None
-        result = await whm_preflight_account(
-            session=session,
-            server_ref=server_ref,
-            username=username,
-        )
-        return result if isinstance(result, dict) else None
-
-    targets = _normalized_string_list(args.get("targets"))
-    if not targets:
-        return None
-    results: list[dict[str, object]] = []
-    for target in targets:
-        result = await whm_preflight_csf_entries(
-            session=session,
-            server_ref=server_ref,
-            target=target,
-        )
-        if isinstance(result, dict):
-            results.append(result)
-    return {"ok": True, "results": results}
+    return await template.fetch_postflight_result(
+        tool_name=tool_name,
+        args=args,
+        session=session,
+    )
 
 
-def collect_recent_preflight_evidence(
+def require_matching_preflight(
+    *,
+    tool_name: str,
+    workflow_family: str | None = None,
+    args: dict[str, object],
     working_messages: list[dict[str, object]],
-) -> list[dict[str, object]]:
-    tool_calls_by_id: dict[str, dict[str, object]] = {}
-    evidence: list[dict[str, object]] = []
-
-    for message in _messages_since_last_user(working_messages):
-        parts = message.get("parts")
-        if not isinstance(parts, list):
-            continue
-        for raw_part in parts:
-            part = _coerce_part_record(raw_part)
-            if part is None:
-                continue
-
-            part_type = part.get("type")
-            tool_name = part.get("toolName")
-            if not isinstance(tool_name, str) or not tool_name.startswith(
-                "whm_preflight_"
-            ):
-                continue
-
-            tool_call_id = part.get("toolCallId")
-            if not isinstance(tool_call_id, str) or not tool_call_id:
-                continue
-
-            if part_type == "tool-call":
-                args = part.get("args")
-                args_obj = args if isinstance(args, dict) else {}
-                tool_calls_by_id[tool_call_id] = {
-                    "toolName": tool_name,
-                    "args": json_safe(args_obj),
-                }
-                continue
-
-            if part_type != "tool-result" or part.get("isError") is True:
-                continue
-
-            result = part.get("result")
-            if not isinstance(result, dict):
-                continue
-
-            call = tool_calls_by_id.get(tool_call_id, {})
-            entry: dict[str, object] = {
-                "toolName": tool_name,
-                "result": json_safe(result),
-            }
-            call_args = call.get("args")
-            if isinstance(call_args, dict):
-                entry["args"] = call_args
-            evidence.append(entry)
-
-    return evidence
+    requested_server_id: str | None = None,
+):
+    template = get_workflow_template(tool_name, workflow_family=workflow_family)
+    if template is None:
+        return None
+    return template.require_preflight(
+        tool_name=tool_name,
+        args=args,
+        working_messages=working_messages,
+        requested_server_id=requested_server_id,
+    )
 
 
-def collect_recent_preflight_results(
+def describe_workflow_activity(
+    *,
+    tool_name: str,
+    workflow_family: str | None = None,
+    args: dict[str, object],
+) -> str:
+    template = get_workflow_template(tool_name, workflow_family=workflow_family)
+    if template is not None:
+        activity = template.describe_activity(tool_name=tool_name, args=args)
+        if isinstance(activity, str) and activity.strip():
+            return activity
+    return _humanize_tool_name(tool_name)
+
+
+def build_approval_context(
+    *,
+    tool_name: str,
+    workflow_family: str | None = None,
+    args: dict[str, object],
     working_messages: list[dict[str, object]],
-) -> list[dict[str, object]]:
-    return [
-        {
-            "toolName": item["toolName"],
-            "result": item["result"],
-        }
-        for item in collect_recent_preflight_evidence(working_messages)
-    ]
+) -> dict[str, object]:
+    preflight_results = collect_recent_preflight_results(working_messages)
+    template = get_workflow_template(tool_name, workflow_family=workflow_family)
+    before_state: list[dict[str, str]] = []
+    if template is not None:
+        built_before_state = template.build_before_state(
+            tool_name=tool_name,
+            args=args,
+            preflight_results=preflight_results,
+        )
+        if isinstance(built_before_state, list):
+            before_state = built_before_state
 
-
-def _build_whm_account_lifecycle_workflow(
-    context: WorkflowTemplateContext,
-) -> list[WorkflowTodoItem]:
-    subject = _account_subject(context.tool_name, context.args)
-    action_label = _action_label(context.tool_name)
-    before_account = _matching_account_preflight(
-        preflight_evidence=context.preflight_evidence,
-        args=context.args,
-    )
-    after_account = _postflight_account(context.postflight_result)
-    reason = _normalized_text(context.args.get("reason"))
-
-    reason_step_status = "completed" if reason is not None else "pending"
-    approval_step_status = "pending"
-    execute_step_status = "pending"
-    postflight_step_status = "pending"
-    conclusion_step_status = "pending"
-
-    if context.phase == "waiting_on_user":
-        reason_step_status = "waiting_on_user"
-    elif context.phase == "waiting_on_approval":
-        approval_step_status = "waiting_on_approval"
-    elif context.phase == "executing":
-        approval_step_status = "completed"
-        execute_step_status = "in_progress"
-    elif context.phase == "completed":
-        approval_step_status = "completed"
-        execute_step_status = "completed"
-        postflight_step_status = "completed"
-        conclusion_step_status = "completed"
-    elif context.phase == "denied":
-        approval_step_status = "cancelled"
-        execute_step_status = "cancelled"
-        postflight_step_status = "cancelled"
-        conclusion_step_status = "completed"
-    elif context.phase == "failed":
-        approval_step_status = "completed"
-        execute_step_status = "cancelled"
-        postflight_step_status = "cancelled"
-        conclusion_step_status = "completed"
-
-    if reason is None and context.phase in {"completed", "denied", "failed"}:
-        reason_step_status = "cancelled"
-
-    return [
-        {
-            "content": _preflight_step_content(
-                subject=subject, before_account=before_account
-            ),
-            "status": "completed" if before_account is not None else "in_progress",
-            "priority": "high",
-        },
-        {
-            "content": _reason_step_content(action_label=action_label, reason=reason),
-            "status": cast(Any, reason_step_status),
-            "priority": "high",
-        },
-        {
-            "content": f"Request approval to {action_label} {subject}.",
-            "status": cast(Any, approval_step_status),
-            "priority": "high",
-        },
-        {
-            "content": f"Execute {action_label} for {subject}.",
-            "status": cast(Any, execute_step_status),
-            "priority": "high",
-        },
-        {
-            "content": _postflight_step_content(
-                tool_name=context.tool_name,
-                subject=subject,
-                after_account=after_account,
-                postflight_result=context.postflight_result,
-            ),
-            "status": cast(Any, postflight_step_status),
-            "priority": "high",
-        },
-        {
-            "content": _conclusion_step_content(
-                tool_name=context.tool_name,
-                subject=subject,
-                reason=reason,
-                before_account=before_account,
-                after_account=after_account,
-                result=context.result,
-                phase=context.phase,
-                error_code=context.error_code,
-            ),
-            "status": cast(Any, conclusion_step_status),
-            "priority": "high",
-        },
-    ]
-
-
-def _build_whm_account_contact_email_workflow(
-    context: WorkflowTemplateContext,
-) -> list[WorkflowTodoItem]:
-    subject = _account_subject(context.tool_name, context.args)
-    before_account = _matching_account_preflight(
-        preflight_evidence=context.preflight_evidence,
-        args=context.args,
-    )
-    after_account = _postflight_account(context.postflight_result)
-    reason = _normalized_text(context.args.get("reason"))
-    new_email = _normalized_text(context.args.get("new_email"))
-
-    statuses = _default_step_statuses(reason=reason, phase=context.phase)
-    return [
-        {
-            "content": _preflight_step_content(
-                subject=subject, before_account=before_account
-            ),
-            "status": "completed" if before_account is not None else "in_progress",
-            "priority": "high",
-        },
-        {
-            "content": _reason_step_content(
-                action_label="changing the contact email", reason=reason
-            ),
-            "status": cast(Any, statuses["reason"]),
-            "priority": "high",
-        },
-        {
-            "content": f"Request approval to change the contact email for {subject} to '{new_email or 'the requested value'}'.",
-            "status": cast(Any, statuses["approval"]),
-            "priority": "high",
-        },
-        {
-            "content": f"Execute the contact email change for {subject}.",
-            "status": cast(Any, statuses["execute"]),
-            "priority": "high",
-        },
-        {
-            "content": _contact_email_postflight_step_content(
-                subject=subject,
-                requested_email=new_email,
-                after_account=after_account,
-                postflight_result=context.postflight_result,
-            ),
-            "status": cast(Any, statuses["postflight"]),
-            "priority": "high",
-        },
-        {
-            "content": _contact_email_conclusion_step_content(
-                subject=subject,
-                reason=reason,
-                requested_email=new_email,
-                before_account=before_account,
-                after_account=after_account,
-                result=context.result,
-                phase=context.phase,
-                error_code=context.error_code,
-            ),
-            "status": cast(Any, statuses["conclusion"]),
-            "priority": "high",
-        },
-    ]
-
-
-def _build_whm_csf_batch_workflow(
-    context: WorkflowTemplateContext,
-) -> list[WorkflowTodoItem]:
-    targets = _normalized_string_list(context.args.get("targets"))
-    subject = _csf_subject(context.args)
-    reason = _normalized_text(context.args.get("reason"))
-    before_entries = _matching_csf_preflight_entries(
-        preflight_evidence=context.preflight_evidence,
-        args=context.args,
-    )
-    postflight_entries = _postflight_csf_entries(context.postflight_result)
-    statuses = _default_step_statuses(reason=reason, phase=context.phase)
-    preflight_complete = len(before_entries) == len(targets) and len(targets) > 0
-
-    return [
-        {
-            "content": _csf_preflight_step_content(
-                subject=subject, entries=before_entries, targets=targets
-            ),
-            "status": "completed" if preflight_complete else "in_progress",
-            "priority": "high",
-        },
-        {
-            "content": _reason_step_content(
-                action_label=_csf_action_phrase(context.tool_name), reason=reason
-            ),
-            "status": cast(Any, statuses["reason"]),
-            "priority": "high",
-        },
-        {
-            "content": f"Request approval to {_csf_action_phrase(context.tool_name)} for {subject}.",
-            "status": cast(Any, statuses["approval"]),
-            "priority": "high",
-        },
-        {
-            "content": f"Execute {_csf_action_phrase(context.tool_name)} for {subject}.",
-            "status": cast(Any, statuses["execute"]),
-            "priority": "high",
-        },
-        {
-            "content": _csf_postflight_step_content(
-                tool_name=context.tool_name,
-                subject=subject,
-                entries=postflight_entries,
-                postflight_result=context.postflight_result,
-            ),
-            "status": cast(Any, statuses["postflight"]),
-            "priority": "high",
-        },
-        {
-            "content": _csf_conclusion_step_content(
-                tool_name=context.tool_name,
-                subject=subject,
-                reason=reason,
-                before_entries=before_entries,
-                after_entries=postflight_entries,
-                result=context.result,
-                phase=context.phase,
-                error_code=context.error_code,
-            ),
-            "status": cast(Any, statuses["conclusion"]),
-            "priority": "high",
-        },
-    ]
-
-
-def _default_step_statuses(
-    *, reason: str | None, phase: WorkflowTemplatePhase
-) -> dict[str, str]:
-    statuses = {
-        "reason": "completed" if reason is not None else "pending",
-        "approval": "pending",
-        "execute": "pending",
-        "postflight": "pending",
-        "conclusion": "pending",
+    return {
+        "activity": describe_workflow_activity(
+            tool_name=tool_name,
+            workflow_family=workflow_family,
+            args=args,
+        ),
+        "argumentSummary": _summarize_arguments(args),
+        "beforeState": before_state,
+        "preflightResults": preflight_results,
     }
-    if phase == "waiting_on_user":
-        statuses["reason"] = "waiting_on_user"
-    elif phase == "waiting_on_approval":
-        statuses["approval"] = "waiting_on_approval"
-    elif phase == "executing":
-        statuses["approval"] = "completed"
-        statuses["execute"] = "in_progress"
-    elif phase == "completed":
-        statuses["approval"] = "completed"
-        statuses["execute"] = "completed"
-        statuses["postflight"] = "completed"
-        statuses["conclusion"] = "completed"
-    elif phase == "denied":
-        statuses["approval"] = "cancelled"
-        statuses["execute"] = "cancelled"
-        statuses["postflight"] = "cancelled"
-        statuses["conclusion"] = "completed"
-    elif phase == "failed":
-        statuses["approval"] = "completed"
-        statuses["execute"] = "cancelled"
-        statuses["postflight"] = "cancelled"
-        statuses["conclusion"] = "completed"
-    if reason is None and phase in {"completed", "denied", "failed"}:
-        statuses["reason"] = "cancelled"
-    return statuses
 
 
-def _account_subject(tool_name: str, args: dict[str, object]) -> str:
-    username = _normalized_text(args.get("username")) or "the account"
-    server_ref = _normalized_text(args.get("server_ref"))
-    if server_ref is None:
-        return f"'{username}'"
-    return f"'{username}' on '{server_ref}'"
-
-
-def _action_label(tool_name: str) -> str:
-    if tool_name == "whm_unsuspend_account":
-        return "unsuspend"
-    return "suspend"
-
-
-def _csf_action_phrase(tool_name: str) -> str:
-    mapping = {
-        "whm_csf_unblock": "remove CSF blocks",
-        "whm_csf_allowlist_remove": "remove CSF allowlist entries",
-        "whm_csf_allowlist_add_ttl": "add temporary CSF allowlist entries",
-        "whm_csf_denylist_add_ttl": "add temporary CSF denylist entries",
-    }
-    return mapping.get(tool_name, "apply the CSF change")
-
-
-def _preflight_step_content(
-    *, subject: str, before_account: dict[str, object] | None
-) -> str:
-    if before_account is None:
-        return f"Account lookup / preflight for {subject}."
-
-    state = _account_state(before_account)
-    details: list[str] = [f"state: {state}"]
-    domain = _normalized_text(before_account.get("domain"))
-    if domain is not None:
-        details.append(f"domain: {domain}")
-    contact = _normalized_text(before_account.get("contactemail"))
-    if contact is not None:
-        details.append(f"contact: {contact}")
-    suspend_reason = _normalized_text(before_account.get("suspendreason"))
-    if suspend_reason is not None:
-        details.append(f"suspend reason: {suspend_reason}")
-    return f"Account lookup / preflight for {subject}: {'; '.join(details)}."
-
-
-def _reason_step_content(*, action_label: str, reason: str | None) -> str:
-    if reason is None:
-        return f"Ask for reason if missing before {action_label}ing the account."
-    return f"Reason captured for the {action_label}: {reason}."
-
-
-def _contact_email_postflight_step_content(
-    *,
-    subject: str,
-    requested_email: str | None,
-    after_account: dict[str, object] | None,
-    postflight_result: dict[str, object] | None,
-) -> str:
-    if after_account is None:
-        if (
-            isinstance(postflight_result, dict)
-            and postflight_result.get("ok") is not True
-        ):
-            error_code = (
-                _normalized_text(postflight_result.get("error_code")) or "unknown"
-            )
-            return f"Postflight verification for {subject} could not confirm the contact email ({error_code})."
-        return f"Postflight verification for {subject}."
-    observed_email = _account_email(after_account) or "unknown"
-    return f"Postflight verification for {subject}: expected contact email '{requested_email or 'unknown'}', observed '{observed_email}'."
-
-
-def _contact_email_conclusion_step_content(
-    *,
-    subject: str,
-    reason: str | None,
-    requested_email: str | None,
-    before_account: dict[str, object] | None,
-    after_account: dict[str, object] | None,
-    result: dict[str, object] | None,
-    phase: WorkflowTemplatePhase,
-    error_code: str | None,
-) -> str:
-    before_email = _account_email(before_account) or "unknown"
-    after_email = _account_email(after_account) or before_email
-    reason_suffix = f" Reason: {reason}." if reason is not None else ""
-    if phase == "waiting_on_user":
-        return f"Conclusion with before/after contact email evidence for {subject} after the reason is provided."
-    if phase == "waiting_on_approval":
-        return f"Conclusion with before/after contact email evidence for {subject} after approval and execution.{reason_suffix}"
-    if phase == "executing":
-        return f"Conclusion for {subject} after execution and contact email verification.{reason_suffix}"
-    if phase == "denied":
-        return f"Conclusion: approval denied for {subject}; contact email stayed '{before_email}'.{reason_suffix}"
-    if phase == "failed":
-        return f"Conclusion: contact email change for {subject} did not complete successfully (error: {error_code or 'tool_execution_failed'}). Before email: '{before_email}'.{reason_suffix}"
-    result_status = (
-        _normalized_text(result.get("status")) if isinstance(result, dict) else None
-    )
-    if result_status == "no-op":
-        return f"Conclusion: no-op for {subject}. Contact email remained '{before_email}'.{reason_suffix}"
-    return f"Conclusion: contact email for {subject} moved from '{before_email}' to '{after_email}'.{reason_suffix}"
-
-
-def _csf_subject(args: dict[str, object]) -> str:
-    targets = _normalized_string_list(args.get("targets"))
-    server_ref = _normalized_text(args.get("server_ref")) or "the server"
-    if not targets:
-        return f"the requested targets on '{server_ref}'"
-    return f"{', '.join(repr(target) for target in targets)} on '{server_ref}'"
-
-
-def _csf_preflight_step_content(
-    *, subject: str, entries: list[dict[str, object]], targets: list[str]
-) -> str:
-    if not entries:
-        return f"Account lookup / preflight for {subject}."
-    seen_targets = {_normalized_text(entry.get("target")) for entry in entries}
-    summaries = [
-        f"{entry.get('target')}: {entry.get('verdict')}"
-        for entry in entries
-        if _normalized_text(entry.get("target")) is not None
-    ]
-    missing = [target for target in targets if target not in seen_targets]
-    if missing:
-        summaries.append("missing: " + ", ".join(missing))
-    return f"Account lookup / preflight for {subject}: {'; '.join(summaries)}."
-
-
-def _csf_postflight_step_content(
-    *,
-    tool_name: str,
-    subject: str,
-    entries: list[dict[str, object]],
-    postflight_result: dict[str, object] | None,
-) -> str:
-    if not entries:
-        if (
-            isinstance(postflight_result, dict)
-            and postflight_result.get("ok") is not True
-        ):
-            error_code = (
-                _normalized_text(postflight_result.get("error_code")) or "unknown"
-            )
-            return f"Postflight verification for {subject} could not be completed ({error_code})."
-        return f"Postflight verification for {subject}."
-    expectations = {
-        "whm_csf_unblock": "not blocked",
-        "whm_csf_allowlist_remove": "not allowlisted",
-        "whm_csf_allowlist_add_ttl": "allowlisted",
-        "whm_csf_denylist_add_ttl": "blocked",
-    }
-    expected = expectations.get(tool_name, "updated")
-    summaries = [
-        f"{entry.get('target')}: expected {expected}, observed {entry.get('verdict')}"
-        for entry in entries
-        if _normalized_text(entry.get("target")) is not None
-    ]
-    return f"Postflight verification for {subject}: {'; '.join(summaries)}."
-
-
-def _csf_conclusion_step_content(
-    *,
-    tool_name: str,
-    subject: str,
-    reason: str | None,
-    before_entries: list[dict[str, object]],
-    after_entries: list[dict[str, object]],
-    result: dict[str, object] | None,
-    phase: WorkflowTemplatePhase,
-    error_code: str | None,
-) -> str:
-    reason_suffix = f" Reason: {reason}." if reason is not None else ""
-    if phase == "waiting_on_user":
-        return f"Conclusion with before/after CSF evidence for {subject} after the reason is provided."
-    if phase == "waiting_on_approval":
-        return f"Conclusion with before/after CSF evidence for {subject} after approval and execution.{reason_suffix}"
-    if phase == "executing":
-        return f"Conclusion for {subject} after execution and CSF postflight verification.{reason_suffix}"
-    if phase == "denied":
-        return f"Conclusion: approval denied for {subject}; no CSF change executed.{reason_suffix}"
-    if phase == "failed":
-        return f"Conclusion: CSF change for {subject} did not complete successfully (error: {error_code or 'tool_execution_failed'}).{reason_suffix}"
-    result_items = _result_items(result)
-    changed = [
-        item.get("target") for item in result_items if item.get("status") == "changed"
-    ]
-    noop = [
-        item.get("target") for item in result_items if item.get("status") == "no-op"
-    ]
-    before_summary = _csf_entries_summary(before_entries)
-    after_summary = _csf_entries_summary(after_entries)
-    parts: list[str] = [f"Before: {before_summary}.", f"After: {after_summary}."]
-    if changed:
-        parts.append("Changed: " + ", ".join(str(item) for item in changed if item))
-    if noop:
-        parts.append("No-op: " + ", ".join(str(item) for item in noop if item))
-    return f"Conclusion for {subject}: {' '.join(parts)}{reason_suffix}"
-
-
-def _postflight_step_content(
-    *,
-    tool_name: str,
-    subject: str,
-    after_account: dict[str, object] | None,
-    postflight_result: dict[str, object] | None,
-) -> str:
-    if after_account is None:
-        if (
-            isinstance(postflight_result, dict)
-            and postflight_result.get("ok") is not True
-        ):
-            error_code = (
-                _normalized_text(postflight_result.get("error_code")) or "unknown"
-            )
-            return f"Postflight verification for {subject} could not be completed ({error_code})."
-        return f"Postflight verification for {subject}."
-
-    expected_state = "active" if tool_name == "whm_unsuspend_account" else "suspended"
-    actual_state = _account_state(after_account)
-    return f"Postflight verification for {subject}: expected {expected_state}, observed {actual_state}."
-
-
-def _conclusion_step_content(
-    *,
-    tool_name: str,
-    subject: str,
-    reason: str | None,
-    before_account: dict[str, object] | None,
-    after_account: dict[str, object] | None,
-    result: dict[str, object] | None,
-    phase: WorkflowTemplatePhase,
-    error_code: str | None,
-) -> str:
-    before_state = _account_state(before_account)
-    after_state = _account_state(after_account)
-    before_text = before_state or "unknown"
-    after_text = after_state or before_text
-    reason_suffix = f" Reason: {reason}." if reason is not None else ""
-
-    if phase == "waiting_on_user":
-        return f"Conclusion with before/after evidence for {subject} after the reason is provided."
-    if phase == "waiting_on_approval":
-        return f"Conclusion with before/after evidence for {subject} after approval and execution.{reason_suffix}"
-    if phase == "executing":
-        return f"Conclusion for {subject} after execution and postflight verification.{reason_suffix}"
-    if phase == "denied":
-        return f"Conclusion: approval denied for {subject}; no change executed. Before state remained {before_text}.{reason_suffix}"
-    if phase == "failed":
-        error_text = error_code or "tool_execution_failed"
-        return f"Conclusion: {subject} did not complete successfully (error: {error_text}). Before state: {before_text}.{reason_suffix}"
-
-    result_status = (
-        _normalized_text(result.get("status")) if isinstance(result, dict) else None
-    )
-    if result_status == "no-op":
-        return f"Conclusion: no-op for {subject}. Before state: {before_text}. After state: {after_text}.{reason_suffix}"
-    return f"Conclusion: {subject} moved from {before_text} to {after_text}.{reason_suffix}"
-
-
-def _matching_account_preflight(
-    *, preflight_evidence: list[dict[str, object]], args: dict[str, object]
-) -> dict[str, object] | None:
-    requested_server_ref = _normalized_text(args.get("server_ref"))
-    requested_username = _normalized_text(args.get("username"))
-    for item in preflight_evidence:
-        if item.get("toolName") != "whm_preflight_account":
-            continue
-        item_args = item.get("args")
-        result = item.get("result")
-        if not isinstance(item_args, dict) or not isinstance(result, dict):
-            continue
-        if result.get("ok") is not True:
-            continue
-        if _normalized_text(item_args.get("server_ref")) != requested_server_ref:
-            continue
-        account = result.get("account")
-        if not isinstance(account, dict):
-            continue
-        if _normalized_text(account.get("user")) != requested_username:
-            continue
-        return account
+def infer_waiting_on_user_workflow_from_messages(
+    *, assistant_text: str, working_messages: list[dict[str, object]]
+) -> WorkflowInference | None:
+    for template in _WORKFLOW_TEMPLATES.values():
+        inferred = template.infer_waiting_on_user_workflow(
+            assistant_text=assistant_text,
+            working_messages=working_messages,
+        )
+        if inferred is not None:
+            return inferred
     return None
 
 
-def _matching_csf_preflight_entries(
-    *, preflight_evidence: list[dict[str, object]], args: dict[str, object]
-) -> list[dict[str, object]]:
-    requested_server_ref = _normalized_text(args.get("server_ref"))
-    requested_targets = set(_normalized_string_list(args.get("targets")))
-    matches: list[dict[str, object]] = []
-    for item in preflight_evidence:
-        if item.get("toolName") != "whm_preflight_csf_entries":
-            continue
-        item_args = item.get("args")
-        result = item.get("result")
-        if not isinstance(item_args, dict) or not isinstance(result, dict):
-            continue
-        if result.get("ok") is not True:
-            continue
-        if _normalized_text(item_args.get("server_ref")) != requested_server_ref:
-            continue
-        target = _normalized_text(result.get("target"))
-        if target is None or target not in requested_targets:
-            continue
-        matches.append(result)
-    matches.sort(key=lambda entry: _normalized_text(entry.get("target")) or "")
-    return matches
+def _humanize_tool_name(tool_name: str) -> str:
+    return (
+        " ".join(part.capitalize() for part in tool_name.split("_") if part.strip())
+        or "Tool"
+    )
 
 
-def _postflight_account(
-    postflight_result: dict[str, object] | None,
-) -> dict[str, object] | None:
-    if (
-        not isinstance(postflight_result, dict)
-        or postflight_result.get("ok") is not True
-    ):
-        return None
-    account = postflight_result.get("account")
-    if isinstance(account, dict):
-        return account
-    return None
-
-
-def _postflight_csf_entries(
-    postflight_result: dict[str, object] | None,
-) -> list[dict[str, object]]:
-    if not isinstance(postflight_result, dict):
-        return []
-    results = postflight_result.get("results")
-    if not isinstance(results, list):
-        return []
-    return [item for item in results if isinstance(item, dict)]
-
-
-def _account_state(account: dict[str, object] | None) -> str | None:
-    if not isinstance(account, dict):
-        return None
-    value = account.get("suspended")
+def _format_argument_value(value: object) -> str:
     if isinstance(value, bool):
-        return "suspended" if value else "active"
-    if isinstance(value, int):
-        return "suspended" if value == 1 else "active"
+        return "yes" if value else "no"
+    if isinstance(value, (int, float)):
+        return str(value)
     if isinstance(value, str):
-        return (
-            "suspended"
-            if value.strip().lower() in {"1", "true", "yes", "y"}
-            else "active"
+        return value
+    if value is None:
+        return "none"
+    if isinstance(value, list):
+        return ", ".join(_format_argument_value(item) for item in value[:5])
+    return str(value)
+
+
+def _summarize_arguments(args: dict[str, object]) -> list[dict[str, str]]:
+    hidden_keys = {"api_token", "password", "secret", "token"}
+    items: list[dict[str, str]] = []
+    for key, value in args.items():
+        if key in hidden_keys:
+            continue
+        items.append(
+            {
+                "label": key.replace("_", " ").capitalize(),
+                "value": _format_argument_value(value),
+            }
         )
-    return None
+    return items
 
 
-def _account_email(account: dict[str, object] | None) -> str | None:
-    if not isinstance(account, dict):
-        return None
-    contact = _normalized_text(account.get("contactemail"))
-    if contact is not None:
-        return contact
-    return _normalized_text(account.get("email"))
-
-
-def _normalized_string_list(value: object) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    normalized: list[str] = []
-    for item in value:
-        text = _normalized_text(item)
-        if text is not None:
-            normalized.append(text)
-    return normalized
-
-
-def _result_items(result: dict[str, object] | None) -> list[dict[str, object]]:
-    if not isinstance(result, dict):
-        return []
-    items = result.get("results")
-    if not isinstance(items, list):
-        return []
-    return [item for item in items if isinstance(item, dict)]
-
-
-def _csf_entries_summary(entries: list[dict[str, object]]) -> str:
-    if not entries:
-        return "no evidence"
-    return "; ".join(
-        f"{entry.get('target')}={entry.get('verdict')}"
-        for entry in entries
-        if _normalized_text(entry.get("target")) is not None
-    )
-
-
-def _normalized_text(value: object) -> str | None:
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip()
-    return normalized or None
-
-
-def _coerce_part_record(value: object) -> dict[str, object] | None:
-    return value if isinstance(value, dict) else None
-
-
-def _messages_since_last_user(
-    working_messages: list[dict[str, object]],
-) -> list[dict[str, object]]:
-    last_user_index = -1
-    for index, message in enumerate(working_messages):
-        if message.get("role") == "user":
-            last_user_index = index
-    return working_messages[last_user_index + 1 :]
+for _family, _template in WHM_WORKFLOW_TEMPLATES.items():
+    register_workflow_template(family=_family, template=_template)

--- a/apps/api/src/noa_api/core/workflows/types.py
+++ b/apps/api/src/noa_api/core/workflows/types.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from noa_api.core.json_safety import json_safe
+from noa_api.core.tool_error_sanitizer import SanitizedToolError
+from noa_api.storage.postgres.workflow_todos import WorkflowTodoItem
+
+WorkflowTemplatePhase = Literal[
+    "waiting_on_user",
+    "waiting_on_approval",
+    "executing",
+    "completed",
+    "denied",
+    "failed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowTemplateContext:
+    tool_name: str
+    args: dict[str, object]
+    phase: WorkflowTemplatePhase
+    preflight_evidence: list[dict[str, object]]
+    result: dict[str, object] | None = None
+    postflight_result: dict[str, object] | None = None
+    error_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowInference:
+    tool_name: str
+    args: dict[str, object]
+
+
+class WorkflowTemplate:
+    def build_todos(self, context: WorkflowTemplateContext) -> list[WorkflowTodoItem]:
+        raise NotImplementedError
+
+    def describe_activity(
+        self, *, tool_name: str, args: dict[str, object]
+    ) -> str | None:
+        return None
+
+    def build_before_state(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        preflight_results: list[dict[str, object]],
+    ) -> list[dict[str, str]] | None:
+        return None
+
+    def require_preflight(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        working_messages: list[dict[str, object]],
+        requested_server_id: str | None,
+    ) -> SanitizedToolError | None:
+        return None
+
+    async def fetch_postflight_result(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        session: AsyncSession,
+    ) -> dict[str, object] | None:
+        return None
+
+    def infer_waiting_on_user_workflow(
+        self,
+        *,
+        assistant_text: str,
+        working_messages: list[dict[str, object]],
+    ) -> WorkflowInference | None:
+        return None
+
+
+def collect_recent_preflight_evidence(
+    working_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    tool_calls_by_id: dict[str, dict[str, object]] = {}
+    evidence: list[dict[str, object]] = []
+
+    for message in _messages_since_last_user(working_messages):
+        parts = message.get("parts")
+        if not isinstance(parts, list):
+            continue
+        for raw_part in parts:
+            part = _coerce_part_record(raw_part)
+            if part is None:
+                continue
+
+            part_type = part.get("type")
+            tool_name = part.get("toolName")
+            if not isinstance(tool_name, str) or not tool_name.startswith(
+                "whm_preflight_"
+            ):
+                continue
+
+            tool_call_id = part.get("toolCallId")
+            if not isinstance(tool_call_id, str) or not tool_call_id:
+                continue
+
+            if part_type == "tool-call":
+                args = part.get("args")
+                args_obj = args if isinstance(args, dict) else {}
+                tool_calls_by_id[tool_call_id] = {
+                    "toolName": tool_name,
+                    "args": json_safe(args_obj),
+                }
+                continue
+
+            if part_type != "tool-result" or part.get("isError") is True:
+                continue
+
+            result = part.get("result")
+            if not isinstance(result, dict):
+                continue
+
+            call = tool_calls_by_id.get(tool_call_id, {})
+            entry: dict[str, object] = {
+                "toolName": tool_name,
+                "result": json_safe(result),
+            }
+            call_args = call.get("args")
+            if isinstance(call_args, dict):
+                entry["args"] = call_args
+            evidence.append(entry)
+
+    return evidence
+
+
+def collect_recent_preflight_results(
+    working_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "toolName": item["toolName"],
+            "result": item["result"],
+        }
+        for item in collect_recent_preflight_evidence(working_messages)
+    ]
+
+
+def normalized_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def normalized_string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for item in value:
+        text = normalized_text(item)
+        if text is not None:
+            normalized.append(text)
+    return normalized
+
+
+def _coerce_part_record(value: object) -> dict[str, object] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _messages_since_last_user(
+    working_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    last_user_index = -1
+    for index, message in enumerate(working_messages):
+        if message.get("role") == "user":
+            last_user_index = index
+    return working_messages[last_user_index + 1 :]

--- a/apps/api/src/noa_api/core/workflows/whm.py
+++ b/apps/api/src/noa_api/core/workflows/whm.py
@@ -1,0 +1,1128 @@
+from __future__ import annotations
+
+import re
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from noa_api.core.tool_error_sanitizer import SanitizedToolError
+from noa_api.core.workflows.types import (
+    WorkflowInference,
+    WorkflowTemplate,
+    WorkflowTemplateContext,
+    WorkflowTemplatePhase,
+    collect_recent_preflight_evidence,
+    normalized_string_list,
+    normalized_text,
+)
+from noa_api.storage.postgres.workflow_todos import WorkflowTodoItem
+from noa_api.whm.tools.preflight_tools import (
+    whm_preflight_account,
+    whm_preflight_csf_entries,
+)
+
+
+class _WHMTemplate(WorkflowTemplate):
+    def build_before_state(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        preflight_results: list[dict[str, object]],
+    ) -> list[dict[str, str]] | None:
+        _ = args
+        return _extract_before_state(preflight_results)
+
+
+class _WHMAccountTemplate(_WHMTemplate):
+    def require_preflight(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        working_messages: list[dict[str, object]],
+        requested_server_id: str | None,
+    ) -> SanitizedToolError | None:
+        _ = tool_name
+        return _require_account_preflight(
+            args=args,
+            working_messages=working_messages,
+            requested_server_id=requested_server_id,
+        )
+
+    async def fetch_postflight_result(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        session: AsyncSession,
+    ) -> dict[str, object] | None:
+        _ = tool_name
+        server_ref = normalized_text(args.get("server_ref"))
+        username = normalized_text(args.get("username"))
+        if server_ref is None or username is None:
+            return None
+        result = await whm_preflight_account(
+            session=session,
+            server_ref=server_ref,
+            username=username,
+        )
+        return result if isinstance(result, dict) else None
+
+
+class WHMAccountLifecycleTemplate(_WHMAccountTemplate):
+    def build_todos(self, context: WorkflowTemplateContext) -> list[WorkflowTodoItem]:
+        subject = _account_subject(context.args)
+        action_label = _action_label(context.tool_name)
+        before_account = _matching_account_preflight(
+            preflight_evidence=context.preflight_evidence,
+            args=context.args,
+        )
+        after_account = _postflight_account(context.postflight_result)
+        reason = normalized_text(context.args.get("reason"))
+
+        reason_step_status = "completed" if reason is not None else "pending"
+        approval_step_status = "pending"
+        execute_step_status = "pending"
+        postflight_step_status = "pending"
+        conclusion_step_status = "pending"
+
+        if context.phase == "waiting_on_user":
+            reason_step_status = "waiting_on_user"
+        elif context.phase == "waiting_on_approval":
+            approval_step_status = "waiting_on_approval"
+        elif context.phase == "executing":
+            approval_step_status = "completed"
+            execute_step_status = "in_progress"
+        elif context.phase == "completed":
+            approval_step_status = "completed"
+            execute_step_status = "completed"
+            postflight_step_status = "completed"
+            conclusion_step_status = "completed"
+        elif context.phase == "denied":
+            approval_step_status = "cancelled"
+            execute_step_status = "cancelled"
+            postflight_step_status = "cancelled"
+            conclusion_step_status = "completed"
+        elif context.phase == "failed":
+            approval_step_status = "completed"
+            execute_step_status = "cancelled"
+            postflight_step_status = "cancelled"
+            conclusion_step_status = "completed"
+
+        if reason is None and context.phase in {"completed", "denied", "failed"}:
+            reason_step_status = "cancelled"
+
+        return [
+            {
+                "content": _preflight_step_content(
+                    subject=subject, before_account=before_account
+                ),
+                "status": "completed" if before_account is not None else "in_progress",
+                "priority": "high",
+            },
+            {
+                "content": _reason_step_content(
+                    action_label=action_label, reason=reason
+                ),
+                "status": cast(Any, reason_step_status),
+                "priority": "high",
+            },
+            {
+                "content": f"Request approval to {action_label} {subject}.",
+                "status": cast(Any, approval_step_status),
+                "priority": "high",
+            },
+            {
+                "content": f"Execute {action_label} for {subject}.",
+                "status": cast(Any, execute_step_status),
+                "priority": "high",
+            },
+            {
+                "content": _postflight_step_content(
+                    tool_name=context.tool_name,
+                    subject=subject,
+                    after_account=after_account,
+                    postflight_result=context.postflight_result,
+                ),
+                "status": cast(Any, postflight_step_status),
+                "priority": "high",
+            },
+            {
+                "content": _conclusion_step_content(
+                    tool_name=context.tool_name,
+                    subject=subject,
+                    reason=reason,
+                    before_account=before_account,
+                    after_account=after_account,
+                    result=context.result,
+                    phase=context.phase,
+                    error_code=context.error_code,
+                ),
+                "status": cast(Any, conclusion_step_status),
+                "priority": "high",
+            },
+        ]
+
+    def describe_activity(
+        self, *, tool_name: str, args: dict[str, object]
+    ) -> str | None:
+        _ = args
+        username = _format_argument_value(args.get("username", "unknown"))
+        if tool_name == "whm_unsuspend_account":
+            return f"Unsuspend account '{username}'"
+        return f"Suspend account '{username}'"
+
+    def infer_waiting_on_user_workflow(
+        self,
+        *,
+        assistant_text: str,
+        working_messages: list[dict[str, object]],
+    ) -> WorkflowInference | None:
+        _ = assistant_text
+        last_user_text = _latest_user_text(working_messages)
+        if last_user_text is None:
+            return None
+
+        tool_name = _infer_whm_account_lifecycle_tool_name(last_user_text)
+        if tool_name is None:
+            return None
+
+        account_candidates = _account_preflight_candidates(working_messages)
+        if not account_candidates:
+            return None
+
+        match = _select_account_preflight_candidate(
+            account_candidates=account_candidates,
+            user_text=last_user_text,
+        )
+        if match is None:
+            return None
+
+        args = cast(dict[str, object], match.get("args"))
+        server_ref = normalized_text(args.get("server_ref"))
+        username = normalized_text(args.get("username"))
+        if server_ref is None or username is None:
+            return None
+
+        return WorkflowInference(
+            tool_name=tool_name,
+            args={
+                "server_ref": server_ref,
+                "username": username,
+            },
+        )
+
+
+class WHMAccountContactEmailTemplate(_WHMAccountTemplate):
+    def build_todos(self, context: WorkflowTemplateContext) -> list[WorkflowTodoItem]:
+        subject = _account_subject(context.args)
+        before_account = _matching_account_preflight(
+            preflight_evidence=context.preflight_evidence,
+            args=context.args,
+        )
+        after_account = _postflight_account(context.postflight_result)
+        reason = normalized_text(context.args.get("reason"))
+        new_email = normalized_text(context.args.get("new_email"))
+
+        statuses = _default_step_statuses(reason=reason, phase=context.phase)
+        return [
+            {
+                "content": _preflight_step_content(
+                    subject=subject, before_account=before_account
+                ),
+                "status": "completed" if before_account is not None else "in_progress",
+                "priority": "high",
+            },
+            {
+                "content": _reason_step_content(
+                    action_label="changing the contact email", reason=reason
+                ),
+                "status": cast(Any, statuses["reason"]),
+                "priority": "high",
+            },
+            {
+                "content": f"Request approval to change the contact email for {subject} to '{new_email or 'the requested value'}'.",
+                "status": cast(Any, statuses["approval"]),
+                "priority": "high",
+            },
+            {
+                "content": f"Execute the contact email change for {subject}.",
+                "status": cast(Any, statuses["execute"]),
+                "priority": "high",
+            },
+            {
+                "content": _contact_email_postflight_step_content(
+                    subject=subject,
+                    requested_email=new_email,
+                    after_account=after_account,
+                    postflight_result=context.postflight_result,
+                ),
+                "status": cast(Any, statuses["postflight"]),
+                "priority": "high",
+            },
+            {
+                "content": _contact_email_conclusion_step_content(
+                    subject=subject,
+                    reason=reason,
+                    requested_email=new_email,
+                    before_account=before_account,
+                    after_account=after_account,
+                    result=context.result,
+                    phase=context.phase,
+                    error_code=context.error_code,
+                ),
+                "status": cast(Any, statuses["conclusion"]),
+                "priority": "high",
+            },
+        ]
+
+    def describe_activity(
+        self, *, tool_name: str, args: dict[str, object]
+    ) -> str | None:
+        _ = tool_name
+        return (
+            f"Change contact email for '{args.get('username', 'unknown')}' "
+            f"to '{args.get('new_email', 'unknown')}'"
+        )
+
+    def infer_waiting_on_user_workflow(
+        self,
+        *,
+        assistant_text: str,
+        working_messages: list[dict[str, object]],
+    ) -> WorkflowInference | None:
+        _ = assistant_text
+        last_user_text = _latest_user_text(working_messages)
+        if last_user_text is None or "email" not in last_user_text.lower():
+            return None
+
+        new_email = _extract_email(last_user_text)
+        if new_email is None:
+            return None
+
+        account_candidates = _account_preflight_candidates(working_messages)
+        if not account_candidates:
+            return None
+
+        match = _select_account_preflight_candidate(
+            account_candidates=account_candidates,
+            user_text=last_user_text,
+        )
+        if match is None:
+            return None
+
+        args = cast(dict[str, object], match.get("args"))
+        server_ref = normalized_text(args.get("server_ref"))
+        username = normalized_text(args.get("username"))
+        if server_ref is None or username is None:
+            return None
+
+        return WorkflowInference(
+            tool_name="whm_change_contact_email",
+            args={
+                "server_ref": server_ref,
+                "username": username,
+                "new_email": new_email,
+            },
+        )
+
+
+class WHMCSFBatchTemplate(_WHMTemplate):
+    def build_todos(self, context: WorkflowTemplateContext) -> list[WorkflowTodoItem]:
+        targets = normalized_string_list(context.args.get("targets"))
+        subject = _csf_subject(context.args)
+        reason = normalized_text(context.args.get("reason"))
+        before_entries = _matching_csf_preflight_entries(
+            preflight_evidence=context.preflight_evidence,
+            args=context.args,
+        )
+        postflight_entries = _postflight_csf_entries(context.postflight_result)
+        statuses = _default_step_statuses(reason=reason, phase=context.phase)
+        preflight_complete = len(before_entries) == len(targets) and len(targets) > 0
+
+        return [
+            {
+                "content": _csf_preflight_step_content(
+                    subject=subject, entries=before_entries, targets=targets
+                ),
+                "status": "completed" if preflight_complete else "in_progress",
+                "priority": "high",
+            },
+            {
+                "content": _reason_step_content(
+                    action_label=_csf_action_phrase(context.tool_name), reason=reason
+                ),
+                "status": cast(Any, statuses["reason"]),
+                "priority": "high",
+            },
+            {
+                "content": f"Request approval to {_csf_action_phrase(context.tool_name)} for {subject}.",
+                "status": cast(Any, statuses["approval"]),
+                "priority": "high",
+            },
+            {
+                "content": f"Execute {_csf_action_phrase(context.tool_name)} for {subject}.",
+                "status": cast(Any, statuses["execute"]),
+                "priority": "high",
+            },
+            {
+                "content": _csf_postflight_step_content(
+                    tool_name=context.tool_name,
+                    subject=subject,
+                    entries=postflight_entries,
+                    postflight_result=context.postflight_result,
+                ),
+                "status": cast(Any, statuses["postflight"]),
+                "priority": "high",
+            },
+            {
+                "content": _csf_conclusion_step_content(
+                    tool_name=context.tool_name,
+                    subject=subject,
+                    reason=reason,
+                    before_entries=before_entries,
+                    after_entries=postflight_entries,
+                    result=context.result,
+                    phase=context.phase,
+                    error_code=context.error_code,
+                ),
+                "status": cast(Any, statuses["conclusion"]),
+                "priority": "high",
+            },
+        ]
+
+    def describe_activity(
+        self, *, tool_name: str, args: dict[str, object]
+    ) -> str | None:
+        return f"{_csf_activity_phrase(tool_name)} '{_format_argument_value(args.get('targets'))}'"
+
+    def require_preflight(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        working_messages: list[dict[str, object]],
+        requested_server_id: str | None,
+    ) -> SanitizedToolError | None:
+        _ = tool_name
+        return _require_csf_preflight(
+            args=args,
+            working_messages=working_messages,
+            requested_server_id=requested_server_id,
+        )
+
+    async def fetch_postflight_result(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        session: AsyncSession,
+    ) -> dict[str, object] | None:
+        _ = tool_name
+        server_ref = normalized_text(args.get("server_ref"))
+        targets = normalized_string_list(args.get("targets"))
+        if server_ref is None or not targets:
+            return None
+
+        results: list[dict[str, object]] = []
+        for target in targets:
+            result = await whm_preflight_csf_entries(
+                session=session,
+                server_ref=server_ref,
+                target=target,
+            )
+            if isinstance(result, dict):
+                results.append(result)
+        return {"ok": True, "results": results}
+
+
+WORKFLOW_TEMPLATES: dict[str, WorkflowTemplate] = {
+    "whm-account-lifecycle": WHMAccountLifecycleTemplate(),
+    "whm-account-contact-email": WHMAccountContactEmailTemplate(),
+    "whm-csf-batch-change": WHMCSFBatchTemplate(),
+}
+
+
+def _require_account_preflight(
+    *,
+    args: dict[str, object],
+    working_messages: list[dict[str, object]],
+    requested_server_id: str | None,
+) -> SanitizedToolError | None:
+    requested_server_ref = normalized_text(args.get("server_ref"))
+    requested_username = normalized_text(args.get("username"))
+    if requested_server_ref is None or requested_username is None:
+        return None
+
+    evidence = [
+        item
+        for item in collect_recent_preflight_evidence(working_messages)
+        if item.get("toolName") == "whm_preflight_account"
+        and isinstance(item.get("result"), dict)
+        and cast(dict[str, object], item["result"]).get("ok") is True
+    ]
+    if not evidence:
+        return SanitizedToolError(
+            error="Required WHM preflight evidence is missing",
+            error_code="preflight_required",
+            details=(
+                "Run whm_preflight_account with the same server_ref and username before requesting this change.",
+            ),
+        )
+
+    for item in evidence:
+        item_args = item.get("args")
+        result = item.get("result")
+        if not isinstance(item_args, dict) or not isinstance(result, dict):
+            continue
+        if not _server_identity_matches(
+            item_args=item_args,
+            result=result,
+            requested_server_ref=requested_server_ref,
+            requested_server_id=requested_server_id,
+        ):
+            continue
+        account = result.get("account")
+        if not isinstance(account, dict):
+            continue
+        if normalized_text(account.get("user")) == requested_username:
+            return None
+
+    return SanitizedToolError(
+        error="Required WHM preflight evidence does not match this change request",
+        error_code="preflight_mismatch",
+        details=(
+            f"No successful whm_preflight_account was found for server_ref '{requested_server_ref}' and username '{requested_username}' in the current turn.",
+        ),
+    )
+
+
+def _require_csf_preflight(
+    *,
+    args: dict[str, object],
+    working_messages: list[dict[str, object]],
+    requested_server_id: str | None,
+) -> SanitizedToolError | None:
+    requested_server_ref = normalized_text(args.get("server_ref"))
+    requested_targets = normalized_string_list(args.get("targets"))
+    if requested_server_ref is None or not requested_targets:
+        return None
+
+    evidence = [
+        item
+        for item in collect_recent_preflight_evidence(working_messages)
+        if item.get("toolName") == "whm_preflight_csf_entries"
+        and isinstance(item.get("result"), dict)
+        and cast(dict[str, object], item["result"]).get("ok") is True
+    ]
+    if not evidence:
+        return SanitizedToolError(
+            error="Required WHM preflight evidence is missing",
+            error_code="preflight_required",
+            details=(
+                "Run whm_preflight_csf_entries for each target with the same server_ref before requesting this change.",
+            ),
+        )
+
+    matched_targets: set[str] = set()
+    for item in evidence:
+        item_args = item.get("args")
+        result = item.get("result")
+        if not isinstance(item_args, dict) or not isinstance(result, dict):
+            continue
+        if not _server_identity_matches(
+            item_args=item_args,
+            result=result,
+            requested_server_ref=requested_server_ref,
+            requested_server_id=requested_server_id,
+        ):
+            continue
+        target = normalized_text(result.get("target"))
+        if target is not None:
+            matched_targets.add(target)
+
+    missing_targets = [
+        target for target in requested_targets if target not in matched_targets
+    ]
+    if not missing_targets:
+        return None
+
+    return SanitizedToolError(
+        error="Required WHM preflight evidence does not match this change request",
+        error_code="preflight_mismatch",
+        details=(
+            "Missing successful whm_preflight_csf_entries results for target(s): "
+            + ", ".join(f"'{target}'" for target in missing_targets),
+        ),
+    )
+
+
+def _server_identity_matches(
+    *,
+    item_args: dict[str, object],
+    result: dict[str, object],
+    requested_server_ref: str,
+    requested_server_id: str | None,
+) -> bool:
+    result_server_id = normalized_text(result.get("server_id"))
+    if requested_server_id is not None and result_server_id is not None:
+        return result_server_id == requested_server_id
+    return normalized_text(item_args.get("server_ref")) == requested_server_ref
+
+
+def _account_preflight_candidates(
+    working_messages: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    return [
+        item
+        for item in collect_recent_preflight_evidence(working_messages)
+        if item.get("toolName") == "whm_preflight_account"
+        and isinstance(item.get("args"), dict)
+    ]
+
+
+def _latest_user_text(working_messages: list[dict[str, object]]) -> str | None:
+    for message in reversed(working_messages):
+        if message.get("role") != "user":
+            continue
+        parts = message.get("parts")
+        if not isinstance(parts, list):
+            continue
+        for part in parts:
+            if not isinstance(part, dict) or part.get("type") != "text":
+                continue
+            text = part.get("text")
+            if isinstance(text, str) and text.strip():
+                return text.strip()
+    return None
+
+
+def _infer_whm_account_lifecycle_tool_name(user_text: str) -> str | None:
+    lowered = user_text.lower()
+    if "unsuspend" in lowered:
+        return "whm_unsuspend_account"
+    if "suspend" in lowered:
+        return "whm_suspend_account"
+    return None
+
+
+def _select_account_preflight_candidate(
+    *, account_candidates: list[dict[str, object]], user_text: str
+) -> dict[str, object] | None:
+    if len(account_candidates) == 1:
+        return account_candidates[0]
+
+    lowered = user_text.lower()
+    for candidate in reversed(account_candidates):
+        args = candidate.get("args")
+        if not isinstance(args, dict):
+            continue
+        server_ref = normalized_text(args.get("server_ref"))
+        username = normalized_text(args.get("username"))
+        if server_ref is None or username is None:
+            continue
+        if server_ref.lower() in lowered and username.lower() in lowered:
+            return candidate
+
+    return None
+
+
+def _extract_email(text: str) -> str | None:
+    match = re.search(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", text)
+    return match.group(0) if match is not None else None
+
+
+def _format_argument_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "none"
+    if isinstance(value, list):
+        return ", ".join(_format_argument_value(item) for item in value[:5])
+    return str(value)
+
+
+def _extract_before_state(
+    preflight_results: list[dict[str, object]],
+) -> list[dict[str, str]]:
+    before_state: list[dict[str, str]] = []
+    for item in preflight_results:
+        tool_name = item.get("toolName")
+        result = item.get("result")
+        if not isinstance(tool_name, str) or not isinstance(result, dict):
+            continue
+        if tool_name == "whm_preflight_account":
+            account = result.get("account")
+            if isinstance(account, dict):
+                for key, label in (
+                    ("user", "Username"),
+                    ("domain", "Domain"),
+                    ("contactemail", "Contact email"),
+                    ("suspended", "Suspended"),
+                    ("suspendreason", "Suspend reason"),
+                    ("plan", "Plan"),
+                ):
+                    value = account.get(key)
+                    if value in (None, ""):
+                        continue
+                    before_state.append(
+                        {"label": label, "value": _format_argument_value(value)}
+                    )
+        if tool_name == "whm_preflight_csf_entries":
+            verdict = result.get("verdict")
+            target = result.get("target")
+            if target not in (None, ""):
+                before_state.append(
+                    {"label": "Target", "value": _format_argument_value(target)}
+                )
+            if verdict not in (None, ""):
+                before_state.append(
+                    {
+                        "label": "Current CSF state",
+                        "value": _format_argument_value(verdict),
+                    }
+                )
+            matches = result.get("matches")
+            if isinstance(matches, list) and matches:
+                before_state.append(
+                    {
+                        "label": "Matched entries",
+                        "value": "; ".join(
+                            _format_argument_value(match) for match in matches[:3]
+                        ),
+                    }
+                )
+    return before_state
+
+
+def _default_step_statuses(
+    *, reason: str | None, phase: WorkflowTemplatePhase
+) -> dict[str, str]:
+    statuses = {
+        "reason": "completed" if reason is not None else "pending",
+        "approval": "pending",
+        "execute": "pending",
+        "postflight": "pending",
+        "conclusion": "pending",
+    }
+    if phase == "waiting_on_user":
+        statuses["reason"] = "waiting_on_user"
+    elif phase == "waiting_on_approval":
+        statuses["approval"] = "waiting_on_approval"
+    elif phase == "executing":
+        statuses["approval"] = "completed"
+        statuses["execute"] = "in_progress"
+    elif phase == "completed":
+        statuses["approval"] = "completed"
+        statuses["execute"] = "completed"
+        statuses["postflight"] = "completed"
+        statuses["conclusion"] = "completed"
+    elif phase == "denied":
+        statuses["approval"] = "cancelled"
+        statuses["execute"] = "cancelled"
+        statuses["postflight"] = "cancelled"
+        statuses["conclusion"] = "completed"
+    elif phase == "failed":
+        statuses["approval"] = "completed"
+        statuses["execute"] = "cancelled"
+        statuses["postflight"] = "cancelled"
+        statuses["conclusion"] = "completed"
+    if reason is None and phase in {"completed", "denied", "failed"}:
+        statuses["reason"] = "cancelled"
+    return statuses
+
+
+def _account_subject(args: dict[str, object]) -> str:
+    username = normalized_text(args.get("username")) or "the account"
+    server_ref = normalized_text(args.get("server_ref"))
+    if server_ref is None:
+        return f"'{username}'"
+    return f"'{username}' on '{server_ref}'"
+
+
+def _action_label(tool_name: str) -> str:
+    if tool_name == "whm_unsuspend_account":
+        return "unsuspend"
+    return "suspend"
+
+
+def _csf_action_phrase(tool_name: str) -> str:
+    mapping = {
+        "whm_csf_unblock": "remove CSF blocks",
+        "whm_csf_allowlist_remove": "remove CSF allowlist entries",
+        "whm_csf_allowlist_add_ttl": "add temporary CSF allowlist entries",
+        "whm_csf_denylist_add_ttl": "add temporary CSF denylist entries",
+    }
+    return mapping.get(tool_name, "apply the CSF change")
+
+
+def _csf_activity_phrase(tool_name: str) -> str:
+    mapping = {
+        "whm_csf_unblock": "Remove CSF block for",
+        "whm_csf_allowlist_remove": "Remove",
+        "whm_csf_allowlist_add_ttl": "Add",
+        "whm_csf_denylist_add_ttl": "Add",
+    }
+    return mapping.get(tool_name, "Apply CSF change for")
+
+
+def _preflight_step_content(
+    *, subject: str, before_account: dict[str, object] | None
+) -> str:
+    if before_account is None:
+        return f"Account lookup / preflight for {subject}."
+
+    state = _account_state(before_account)
+    details: list[str] = [f"state: {state}"]
+    domain = normalized_text(before_account.get("domain"))
+    if domain is not None:
+        details.append(f"domain: {domain}")
+    contact = normalized_text(before_account.get("contactemail"))
+    if contact is not None:
+        details.append(f"contact: {contact}")
+    suspend_reason = normalized_text(before_account.get("suspendreason"))
+    if suspend_reason is not None:
+        details.append(f"suspend reason: {suspend_reason}")
+    return f"Account lookup / preflight for {subject}: {'; '.join(details)}."
+
+
+def _reason_step_content(*, action_label: str, reason: str | None) -> str:
+    if reason is None:
+        return f"Ask for reason if missing before {action_label}ing the account."
+    return f"Reason captured for the {action_label}: {reason}."
+
+
+def _contact_email_postflight_step_content(
+    *,
+    subject: str,
+    requested_email: str | None,
+    after_account: dict[str, object] | None,
+    postflight_result: dict[str, object] | None,
+) -> str:
+    if after_account is None:
+        if (
+            isinstance(postflight_result, dict)
+            and postflight_result.get("ok") is not True
+        ):
+            error_code = (
+                normalized_text(postflight_result.get("error_code")) or "unknown"
+            )
+            return f"Postflight verification for {subject} could not confirm the contact email ({error_code})."
+        return f"Postflight verification for {subject}."
+    observed_email = _account_email(after_account) or "unknown"
+    return f"Postflight verification for {subject}: expected contact email '{requested_email or 'unknown'}', observed '{observed_email}'."
+
+
+def _contact_email_conclusion_step_content(
+    *,
+    subject: str,
+    reason: str | None,
+    requested_email: str | None,
+    before_account: dict[str, object] | None,
+    after_account: dict[str, object] | None,
+    result: dict[str, object] | None,
+    phase: WorkflowTemplatePhase,
+    error_code: str | None,
+) -> str:
+    before_email = _account_email(before_account) or "unknown"
+    after_email = _account_email(after_account) or before_email
+    reason_suffix = f" Reason: {reason}." if reason is not None else ""
+    if phase == "waiting_on_user":
+        return f"Conclusion with before/after contact email evidence for {subject} after the reason is provided."
+    if phase == "waiting_on_approval":
+        return f"Conclusion with before/after contact email evidence for {subject} after approval and execution.{reason_suffix}"
+    if phase == "executing":
+        return f"Conclusion for {subject} after execution and contact email verification.{reason_suffix}"
+    if phase == "denied":
+        return f"Conclusion: approval denied for {subject}; contact email stayed '{before_email}'.{reason_suffix}"
+    if phase == "failed":
+        return f"Conclusion: contact email change for {subject} did not complete successfully (error: {error_code or 'tool_execution_failed'}). Before email: '{before_email}'.{reason_suffix}"
+    result_status = (
+        normalized_text(result.get("status")) if isinstance(result, dict) else None
+    )
+    if result_status == "no-op":
+        return f"Conclusion: no-op for {subject}. Contact email remained '{before_email}'.{reason_suffix}"
+    return f"Conclusion: contact email for {subject} moved from '{before_email}' to '{after_email}'.{reason_suffix}"
+
+
+def _csf_subject(args: dict[str, object]) -> str:
+    targets = normalized_string_list(args.get("targets"))
+    server_ref = normalized_text(args.get("server_ref")) or "the server"
+    if not targets:
+        return f"the requested targets on '{server_ref}'"
+    return f"{', '.join(repr(target) for target in targets)} on '{server_ref}'"
+
+
+def _csf_preflight_step_content(
+    *, subject: str, entries: list[dict[str, object]], targets: list[str]
+) -> str:
+    if not entries:
+        return f"Account lookup / preflight for {subject}."
+    seen_targets = {normalized_text(entry.get("target")) for entry in entries}
+    summaries = [
+        f"{entry.get('target')}: {entry.get('verdict')}"
+        for entry in entries
+        if normalized_text(entry.get("target")) is not None
+    ]
+    missing = [target for target in targets if target not in seen_targets]
+    if missing:
+        summaries.append("missing: " + ", ".join(missing))
+    return f"Account lookup / preflight for {subject}: {'; '.join(summaries)}."
+
+
+def _csf_postflight_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    entries: list[dict[str, object]],
+    postflight_result: dict[str, object] | None,
+) -> str:
+    if not entries:
+        if (
+            isinstance(postflight_result, dict)
+            and postflight_result.get("ok") is not True
+        ):
+            error_code = (
+                normalized_text(postflight_result.get("error_code")) or "unknown"
+            )
+            return f"Postflight verification for {subject} could not be completed ({error_code})."
+        return f"Postflight verification for {subject}."
+    expectations = {
+        "whm_csf_unblock": "not blocked",
+        "whm_csf_allowlist_remove": "not allowlisted",
+        "whm_csf_allowlist_add_ttl": "allowlisted",
+        "whm_csf_denylist_add_ttl": "blocked",
+    }
+    expected = expectations.get(tool_name, "updated")
+    summaries = [
+        f"{entry.get('target')}: expected {expected}, observed {entry.get('verdict')}"
+        for entry in entries
+        if normalized_text(entry.get("target")) is not None
+    ]
+    return f"Postflight verification for {subject}: {'; '.join(summaries)}."
+
+
+def _csf_conclusion_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    reason: str | None,
+    before_entries: list[dict[str, object]],
+    after_entries: list[dict[str, object]],
+    result: dict[str, object] | None,
+    phase: WorkflowTemplatePhase,
+    error_code: str | None,
+) -> str:
+    _ = tool_name
+    reason_suffix = f" Reason: {reason}." if reason is not None else ""
+    if phase == "waiting_on_user":
+        return f"Conclusion with before/after CSF evidence for {subject} after the reason is provided."
+    if phase == "waiting_on_approval":
+        return f"Conclusion with before/after CSF evidence for {subject} after approval and execution.{reason_suffix}"
+    if phase == "executing":
+        return f"Conclusion for {subject} after execution and CSF postflight verification.{reason_suffix}"
+    if phase == "denied":
+        return f"Conclusion: approval denied for {subject}; no CSF change executed.{reason_suffix}"
+    if phase == "failed":
+        return f"Conclusion: CSF change for {subject} did not complete successfully (error: {error_code or 'tool_execution_failed'}).{reason_suffix}"
+    result_items = _result_items(result)
+    changed = [
+        item.get("target") for item in result_items if item.get("status") == "changed"
+    ]
+    noop = [
+        item.get("target") for item in result_items if item.get("status") == "no-op"
+    ]
+    before_summary = _csf_entries_summary(before_entries)
+    after_summary = _csf_entries_summary(after_entries)
+    parts: list[str] = [f"Before: {before_summary}.", f"After: {after_summary}."]
+    if changed:
+        parts.append("Changed: " + ", ".join(str(item) for item in changed if item))
+    if noop:
+        parts.append("No-op: " + ", ".join(str(item) for item in noop if item))
+    return f"Conclusion for {subject}: {' '.join(parts)}{reason_suffix}"
+
+
+def _postflight_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    after_account: dict[str, object] | None,
+    postflight_result: dict[str, object] | None,
+) -> str:
+    if after_account is None:
+        if (
+            isinstance(postflight_result, dict)
+            and postflight_result.get("ok") is not True
+        ):
+            error_code = (
+                normalized_text(postflight_result.get("error_code")) or "unknown"
+            )
+            return f"Postflight verification for {subject} could not be completed ({error_code})."
+        return f"Postflight verification for {subject}."
+
+    expected_state = "active" if tool_name == "whm_unsuspend_account" else "suspended"
+    actual_state = _account_state(after_account)
+    return f"Postflight verification for {subject}: expected {expected_state}, observed {actual_state}."
+
+
+def _conclusion_step_content(
+    *,
+    tool_name: str,
+    subject: str,
+    reason: str | None,
+    before_account: dict[str, object] | None,
+    after_account: dict[str, object] | None,
+    result: dict[str, object] | None,
+    phase: WorkflowTemplatePhase,
+    error_code: str | None,
+) -> str:
+    _ = tool_name
+    before_state = _account_state(before_account)
+    after_state = _account_state(after_account)
+    before_text = before_state or "unknown"
+    after_text = after_state or before_text
+    reason_suffix = f" Reason: {reason}." if reason is not None else ""
+
+    if phase == "waiting_on_user":
+        return f"Conclusion with before/after evidence for {subject} after the reason is provided."
+    if phase == "waiting_on_approval":
+        return f"Conclusion with before/after evidence for {subject} after approval and execution.{reason_suffix}"
+    if phase == "executing":
+        return f"Conclusion for {subject} after execution and postflight verification.{reason_suffix}"
+    if phase == "denied":
+        return f"Conclusion: approval denied for {subject}; no change executed. Before state remained {before_text}.{reason_suffix}"
+    if phase == "failed":
+        error_text = error_code or "tool_execution_failed"
+        return f"Conclusion: {subject} did not complete successfully (error: {error_text}). Before state: {before_text}.{reason_suffix}"
+
+    result_status = (
+        normalized_text(result.get("status")) if isinstance(result, dict) else None
+    )
+    if result_status == "no-op":
+        return f"Conclusion: no-op for {subject}. Before state: {before_text}. After state: {after_text}.{reason_suffix}"
+    return f"Conclusion: {subject} moved from {before_text} to {after_text}.{reason_suffix}"
+
+
+def _matching_account_preflight(
+    *, preflight_evidence: list[dict[str, object]], args: dict[str, object]
+) -> dict[str, object] | None:
+    requested_server_ref = normalized_text(args.get("server_ref"))
+    requested_username = normalized_text(args.get("username"))
+    for item in preflight_evidence:
+        if item.get("toolName") != "whm_preflight_account":
+            continue
+        item_args = item.get("args")
+        result = item.get("result")
+        if not isinstance(item_args, dict) or not isinstance(result, dict):
+            continue
+        if result.get("ok") is not True:
+            continue
+        if normalized_text(item_args.get("server_ref")) != requested_server_ref:
+            continue
+        account = result.get("account")
+        if not isinstance(account, dict):
+            continue
+        if normalized_text(account.get("user")) != requested_username:
+            continue
+        return account
+    return None
+
+
+def _matching_csf_preflight_entries(
+    *, preflight_evidence: list[dict[str, object]], args: dict[str, object]
+) -> list[dict[str, object]]:
+    requested_server_ref = normalized_text(args.get("server_ref"))
+    requested_targets = set(normalized_string_list(args.get("targets")))
+    matches: list[dict[str, object]] = []
+    for item in preflight_evidence:
+        if item.get("toolName") != "whm_preflight_csf_entries":
+            continue
+        item_args = item.get("args")
+        result = item.get("result")
+        if not isinstance(item_args, dict) or not isinstance(result, dict):
+            continue
+        if result.get("ok") is not True:
+            continue
+        if normalized_text(item_args.get("server_ref")) != requested_server_ref:
+            continue
+        target = normalized_text(result.get("target"))
+        if target is None or target not in requested_targets:
+            continue
+        matches.append(result)
+    matches.sort(key=lambda entry: normalized_text(entry.get("target")) or "")
+    return matches
+
+
+def _postflight_account(
+    postflight_result: dict[str, object] | None,
+) -> dict[str, object] | None:
+    if (
+        not isinstance(postflight_result, dict)
+        or postflight_result.get("ok") is not True
+    ):
+        return None
+    account = postflight_result.get("account")
+    if isinstance(account, dict):
+        return account
+    return None
+
+
+def _postflight_csf_entries(
+    postflight_result: dict[str, object] | None,
+) -> list[dict[str, object]]:
+    if not isinstance(postflight_result, dict):
+        return []
+    results = postflight_result.get("results")
+    if not isinstance(results, list):
+        return []
+    return [item for item in results if isinstance(item, dict)]
+
+
+def _account_state(account: dict[str, object] | None) -> str | None:
+    if not isinstance(account, dict):
+        return None
+    value = account.get("suspended")
+    if isinstance(value, bool):
+        return "suspended" if value else "active"
+    if isinstance(value, int):
+        return "suspended" if value == 1 else "active"
+    if isinstance(value, str):
+        return (
+            "suspended"
+            if value.strip().lower() in {"1", "true", "yes", "y"}
+            else "active"
+        )
+    return None
+
+
+def _account_email(account: dict[str, object] | None) -> str | None:
+    if not isinstance(account, dict):
+        return None
+    contact = normalized_text(account.get("contactemail"))
+    if contact is not None:
+        return contact
+    return normalized_text(account.get("email"))
+
+
+def _result_items(result: dict[str, object] | None) -> list[dict[str, object]]:
+    if not isinstance(result, dict):
+        return []
+    items = result.get("results")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _csf_entries_summary(entries: list[dict[str, object]]) -> str:
+    if not entries:
+        return "no evidence"
+    return "; ".join(
+        f"{entry.get('target')}={entry.get('verdict')}"
+        for entry in entries
+        if normalized_text(entry.get("target")) is not None
+    )

--- a/apps/api/tests/test_workflow_registry.py
+++ b/apps/api/tests/test_workflow_registry.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from noa_api.core.tool_error_sanitizer import SanitizedToolError
+from noa_api.core.workflows.registry import (
+    build_approval_context,
+    build_workflow_todos,
+    describe_workflow_activity,
+    fetch_postflight_result,
+    infer_waiting_on_user_workflow_from_messages,
+    list_registered_workflow_families,
+    register_workflow_template,
+    require_matching_preflight,
+)
+from noa_api.core.workflows.types import (
+    WorkflowInference,
+    WorkflowTemplate,
+    WorkflowTemplateContext,
+)
+
+
+class _CustomWorkflowTemplate(WorkflowTemplate):
+    def build_todos(self, context: WorkflowTemplateContext):
+        return [
+            {
+                "content": f"Registered step for {context.tool_name}.",
+                "status": "waiting_on_approval",
+                "priority": "high",
+            }
+        ]
+
+    def describe_activity(
+        self, *, tool_name: str, args: dict[str, object]
+    ) -> str | None:
+        _ = tool_name, args
+        return "Run custom workflow"
+
+    def build_before_state(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        preflight_results: list[dict[str, object]],
+    ) -> list[dict[str, str]] | None:
+        _ = tool_name, args, preflight_results
+        return [{"label": "Before", "value": "ready"}]
+
+    def require_preflight(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, object],
+        working_messages: list[dict[str, object]],
+        requested_server_id: str | None,
+    ) -> SanitizedToolError | None:
+        _ = tool_name, args, working_messages, requested_server_id
+        return SanitizedToolError(
+            error="Custom preflight missing",
+            error_code="custom_preflight_required",
+        )
+
+    async def fetch_postflight_result(
+        self, *, tool_name: str, args: dict[str, object], session
+    ):
+        _ = tool_name, args, session
+        return {"ok": True, "source": "custom-template"}
+
+    def infer_waiting_on_user_workflow(
+        self,
+        *,
+        assistant_text: str,
+        working_messages: list[dict[str, object]],
+    ) -> WorkflowInference | None:
+        _ = working_messages
+        if "reason" not in assistant_text.lower():
+            return None
+        return WorkflowInference(tool_name="custom_change", args={"resource": "alpha"})
+
+
+@pytest.mark.asyncio
+async def test_workflow_registry_supports_registered_templates() -> None:
+    family = "test-custom-workflow-family"
+    register_workflow_template(family=family, template=_CustomWorkflowTemplate())
+
+    assert family in list_registered_workflow_families()
+
+    todos = build_workflow_todos(
+        tool_name="custom_change",
+        workflow_family=family,
+        args={"resource": "alpha"},
+        phase="waiting_on_approval",
+        preflight_evidence=[],
+    )
+    assert todos == [
+        {
+            "content": "Registered step for custom_change.",
+            "status": "waiting_on_approval",
+            "priority": "high",
+        }
+    ]
+
+    approval_context = build_approval_context(
+        tool_name="custom_change",
+        workflow_family=family,
+        args={"resource": "alpha"},
+        working_messages=[],
+    )
+    assert approval_context["activity"] == "Run custom workflow"
+    assert approval_context["beforeState"] == [{"label": "Before", "value": "ready"}]
+    assert approval_context["argumentSummary"] == [
+        {"label": "Resource", "value": "alpha"}
+    ]
+
+    preflight_error = require_matching_preflight(
+        tool_name="custom_change",
+        workflow_family=family,
+        args={"resource": "alpha"},
+        working_messages=[],
+    )
+    assert preflight_error is not None
+    assert preflight_error.error_code == "custom_preflight_required"
+
+    postflight_result = await fetch_postflight_result(
+        tool_name="custom_change",
+        workflow_family=family,
+        args={"resource": "alpha"},
+        session=cast(object, object()),
+    )
+    assert postflight_result == {"ok": True, "source": "custom-template"}
+
+    inferred = infer_waiting_on_user_workflow_from_messages(
+        assistant_text="I still need a reason before I can continue.",
+        working_messages=[],
+    )
+    assert inferred == WorkflowInference(
+        tool_name="custom_change",
+        args={"resource": "alpha"},
+    )
+
+    assert (
+        describe_workflow_activity(
+            tool_name="custom_change",
+            workflow_family=family,
+            args={"resource": "alpha"},
+        )
+        == "Run custom workflow"
+    )

--- a/docs/assistant/workflow-templates.md
+++ b/docs/assistant/workflow-templates.md
@@ -1,0 +1,54 @@
+# Workflow templates
+
+NOA workflow UI is driven by canonical workflow todos stored in assistant thread state. To add a new operational tool family, register a workflow template on the API side and keep the web dock/detail UI unchanged.
+
+## How registration works
+
+1. Add a `workflow_family` value to each `ToolDefinition` in `apps/api/src/noa_api/core/tools/registry.py`.
+2. Implement a template in `apps/api/src/noa_api/core/workflows/<family>.py` by subclassing `WorkflowTemplate` from `apps/api/src/noa_api/core/workflows/types.py`.
+3. Register the template in `apps/api/src/noa_api/core/workflows/registry.py` with `register_workflow_template(...)`.
+
+The registry is the orchestration boundary. Once a family is registered, the existing workflow dock, detail sheet, approval cards, and thread state transport continue to work without UI changes.
+
+## Template hooks
+
+- `build_todos(...)`: required; returns canonical workflow steps for each lifecycle phase.
+- `describe_activity(...)`: optional; customizes approval activity copy.
+- `build_before_state(...)`: optional; maps preflight evidence into approval before-state rows.
+- `require_preflight(...)`: optional; blocks unsafe CHANGE requests until matching evidence exists.
+- `fetch_postflight_result(...)`: optional; loads verification evidence after execution.
+- `infer_waiting_on_user_workflow(...)`: optional; seeds a waiting workflow when the assistant asks the user for missing input without emitting a CHANGE tool call yet.
+
+## Family module shape
+
+```python
+from noa_api.core.workflows.types import WorkflowTemplate, WorkflowTemplateContext
+
+
+class ProxmoxVmPowerTemplate(WorkflowTemplate):
+    def build_todos(self, context: WorkflowTemplateContext):
+        return [
+            {"content": "Preflight VM state.", "status": "completed", "priority": "high"},
+            {"content": "Request approval.", "status": "waiting_on_approval", "priority": "high"},
+        ]
+
+
+WORKFLOW_TEMPLATES = {
+    "proxmox-vm-power": ProxmoxVmPowerTemplate(),
+}
+```
+
+Then register it:
+
+```python
+from noa_api.core.workflows.proxmox import WORKFLOW_TEMPLATES as PROXMOX_WORKFLOW_TEMPLATES
+
+for family, template in PROXMOX_WORKFLOW_TEMPLATES.items():
+    register_workflow_template(family=family, template=template)
+```
+
+## Current reference implementation
+
+- Shared contract: `apps/api/src/noa_api/core/workflows/types.py`
+- Registry: `apps/api/src/noa_api/core/workflows/registry.py`
+- WHM templates: `apps/api/src/noa_api/core/workflows/whm.py`


### PR DESCRIPTION
## Summary
- replace the WHM-only workflow switchboard with a registry and shared workflow template contract for todos, approvals, preflight checks, postflight verification, and waiting-on-user inference
- move WHM workflow behavior into dedicated template implementations so new tool families can register themselves without editing core assistant orchestration
- add registry coverage and extension docs for future workflow families

## Testing
- uv run pytest -q

## Issues
- Implements #7
- Tracking #10