### PR TITLE
docs: document workflow template registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,13 @@ Tools + approval gate:
 - Every tool is classified as `ToolRisk.READ` or `ToolRisk.CHANGE`.
 - Any mutating behavior must be `CHANGE` and go through the persisted approval flow (`request_approval` -> approve/deny).
 
+Assistant workflows:
+- Approval-oriented tool families register workflow templates in `apps/api/src/noa_api/core/workflows/registry.py`; avoid adding new family-specific branches in `apps/api/src/noa_api/core/agent/runner.py` when a template hook can own the behavior.
+- Shared workflow contract lives in `apps/api/src/noa_api/core/workflows/types.py`.
+- WHM is the reference implementation in `apps/api/src/noa_api/core/workflows/whm.py`.
+- When adding a new workflow family, set `ToolDefinition.workflow_family`, implement a template module, register it, and keep the existing web workflow UI generic unless the user explicitly asks for a new surface.
+- Canonical workflow UI/docs reference: `docs/assistant/workflow-templates.md`.
+
 ### TypeScript / Next.js (apps/web)
 Imports/formatting:
 - Order imports: React/Next, third-party, then internal `@/`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The model interprets and proposes actions; the platform enforces permissions, ap
 Docs:
 - `ARCHITECTURE.md`
 - `docs/STATUS.md`
+- `docs/assistant/workflow-templates.md`
 - `docs/observability/README.md`
 - `docs/plans/2026-03-09-project-noa-mvp-design.md`
 - `docs/reports/2026-03-09-task-11-verification.md`
@@ -81,6 +82,16 @@ Open: http://localhost:3000
 - Thread persistence (list/create/rename/archive/delete) backed by Postgres
 - Assistant Transport streaming endpoint (`POST /assistant`)
 - Tool registry with READ vs CHANGE risk and explicit approval gate for CHANGE tools
+- Workflow template registry for approval-oriented tool families, with WHM as the reference implementation
+
+## Workflow Templates
+
+Approval-oriented tool families use workflow templates on the API side to drive the assistant workflow dock, approval context, preflight enforcement, postflight verification, and waiting-on-user state.
+
+- Shared contract: `apps/api/src/noa_api/core/workflows/types.py`
+- Registry: `apps/api/src/noa_api/core/workflows/registry.py`
+- WHM family implementation: `apps/api/src/noa_api/core/workflows/whm.py`
+- Extension guide: `docs/assistant/workflow-templates.md`
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary
- add the workflow template registry guide to the top-level README docs list and implementation overview
- document the workflow template architecture in `AGENTS.md` so future changes extend the registry and template hooks instead of adding runner-specific branches
- follow up on the workflow template refactor merged in #17

## Testing
- not run (docs-only change)

## Issues
- Follow-up docs for #7
- closes #7 