### PR TITLE
fix(web): clarify workflow history surfaces

### DIFF
--- a/apps/web/components/assistant/approval-lifecycle-ui.ts
+++ b/apps/web/components/assistant/approval-lifecycle-ui.ts
@@ -24,9 +24,9 @@ export function getApprovalLifecyclePresentation(
   switch (status) {
     case "requested":
       return {
-        title: "Approval requested",
+        title: "Approval needed",
         detail: "Review the proposed change before execution begins.",
-        badge: "requested",
+        badge: "needs approval",
         badgeClassName: "bg-accent/15 text-accent",
         Icon: ClockIcon,
       };
@@ -40,15 +40,15 @@ export function getApprovalLifecyclePresentation(
       };
     case "executing":
       return {
-        title: "Executing approved action",
+        title: "Applying approved change",
         detail: "NOA is running the approved change now.",
-        badge: "executing",
+        badge: "running",
         badgeClassName: "bg-sky-100/80 text-sky-900",
         Icon: RocketIcon,
       };
     case "finished":
       return {
-        title: "Approved action finished",
+        title: "Change complete",
         detail: "The approved change completed successfully.",
         badge: "done",
         badgeClassName: "bg-emerald-100/80 text-emerald-900",
@@ -56,7 +56,7 @@ export function getApprovalLifecyclePresentation(
       };
     case "failed":
       return {
-        title: "Approved action failed",
+        title: "Change failed",
         detail: "The approval succeeded, but the execution did not finish cleanly.",
         badge: "failed",
         badgeClassName: "bg-rose-100/80 text-rose-900",
@@ -64,7 +64,7 @@ export function getApprovalLifecyclePresentation(
       };
     case "denied":
       return {
-        title: "Action request denied",
+        title: "Change denied",
         detail: "Execution stops and the request is now terminal.",
         badge: "denied",
         badgeClassName: "bg-slate-200/80 text-slate-800",

--- a/apps/web/components/assistant/assistant-detail-sheet.tsx
+++ b/apps/web/components/assistant/assistant-detail-sheet.tsx
@@ -53,30 +53,62 @@ export function AssistantDetailSheet() {
               <div className="flex-1 overflow-y-auto px-4 py-4">
                 {detail.kind === "approval" ? (
                   <div className="space-y-3">
-                    {detail.sections.map((section) => (
-                      <section
-                        key={section.title}
-                        className="rounded-xl border border-border bg-bg/35 px-4 py-3"
-                      >
-                        <h3 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
-                          {section.title}
-                        </h3>
-                        <dl className="mt-3 space-y-2 text-sm">
-                          {section.items.map((item) => (
-                            <div
-                              key={`${section.title}-${item.label}-${item.value}`}
-                              className="grid grid-cols-[8rem_minmax(0,1fr)] gap-3"
-                            >
-                              <dt className="text-muted">{item.label}</dt>
-                              <dd className="min-w-0 break-words text-text">{item.value}</dd>
-                            </div>
-                          ))}
-                        </dl>
-                      </section>
-                    ))}
+                    {detail.sections.length > 0 ? (
+                      detail.sections.map((section) => (
+                        <section
+                          key={section.title}
+                          className="rounded-xl border border-border bg-bg/35 px-4 py-3"
+                        >
+                          <h3 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
+                            {section.title}
+                          </h3>
+                          <dl className="mt-3 space-y-2 text-sm">
+                            {section.items.map((item) => (
+                              <div
+                                key={`${section.title}-${item.label}-${item.value}`}
+                                className="grid grid-cols-[8rem_minmax(0,1fr)] gap-3"
+                              >
+                                <dt className="text-muted">{item.label}</dt>
+                                <dd className="min-w-0 break-words text-text">{item.value}</dd>
+                              </div>
+                            ))}
+                          </dl>
+                        </section>
+                      ))
+                    ) : (
+                      <div className="rounded-xl border border-dashed border-border bg-bg/20 px-4 py-3 text-sm text-muted">
+                        No structured evidence is available for this request.
+                      </div>
+                    )}
                   </div>
                 ) : (
                   <div className="space-y-2">
+                    <div className="grid grid-cols-3 gap-2 pb-1">
+                      <div className="rounded-xl border border-border bg-bg/35 px-3 py-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
+                          Completed
+                        </div>
+                        <div className="mt-1 text-sm font-medium text-text">
+                          {detail.todos.filter((todo) => todo.status === "completed").length}
+                        </div>
+                      </div>
+                      <div className="rounded-xl border border-border bg-bg/35 px-3 py-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
+                          Blocked
+                        </div>
+                        <div className="mt-1 text-sm font-medium text-text">
+                          {detail.todos.filter((todo) => isWorkflowTodoBlocked(todo.status)).length}
+                        </div>
+                      </div>
+                      <div className="rounded-xl border border-border bg-bg/35 px-3 py-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
+                          Cancelled
+                        </div>
+                        <div className="mt-1 text-sm font-medium text-text">
+                          {detail.todos.filter((todo) => todo.status === "cancelled").length}
+                        </div>
+                      </div>
+                    </div>
                     {detail.todos.map((todo, index) => {
                       const style = getWorkflowTodoStatusStyle(todo.status);
                       const Icon = style.Icon;

--- a/apps/web/components/assistant/request-approval-tool-ui.tsx
+++ b/apps/web/components/assistant/request-approval-tool-ui.tsx
@@ -70,16 +70,17 @@ function summarizeDetails(items: DetailItem[]): string | null {
 function getReceiptLabel(lifecycleStatus: string): string {
   switch (lifecycleStatus) {
     case "finished":
-      return "Completed";
+      return "Done";
     case "failed":
       return "Failed";
     case "denied":
       return "Denied";
     case "approved":
+      return "Approved";
     case "executing":
-      return "Executing";
+      return "Running";
     default:
-      return "Approval needed";
+      return "Needs approval";
   }
 }
 
@@ -97,13 +98,19 @@ function Actions({ args }: { args: Record<string, unknown> }) {
     )?.lifecycleStatus ?? "requested";
   const copy = getApprovalLifecyclePresentation(lifecycleStatus);
   const detailSheet = useAssistantDetailSheet();
-  const hasDetails = beforeState.length > 0 || argumentSummary.length > 0;
   const [pendingDecision, setPendingDecision] = useState<DecisionState | null>(null);
   const detailKey = `approval:${actionRequestId}`;
   const summaryText = useMemo(
     () => summarizeDetails(argumentSummary) ?? summarizeDetails(beforeState),
     [argumentSummary, beforeState],
   );
+  const risk = coerceString(args.risk) ?? "CHANGE";
+  const overview = [
+    { label: "Status", value: copy.title },
+    { label: "Tool", value: prettifyToolName(toolName) },
+    { label: "Risk", value: risk },
+    { label: "Action ID", value: actionRequestId },
+  ];
 
   useEffect(() => {
     if (lifecycleStatus !== "requested") {
@@ -136,6 +143,7 @@ function Actions({ args }: { args: Record<string, unknown> }) {
       badge: copy.badge,
       badgeClassName: copy.badgeClassName,
       sections: [
+        { title: "Overview", items: overview },
         { title: "Before state", items: beforeState },
         { title: "Requested change", items: argumentSummary },
       ].filter((section) => section.items.length > 0),
@@ -149,7 +157,7 @@ function Actions({ args }: { args: Record<string, unknown> }) {
           <div className="min-w-0">
             <div className="text-sm font-medium text-text">{activity}</div>
             <div className="mt-1 text-xs text-muted">
-              {summaryText ?? "This change needs approval before execution can continue."}
+              {summaryText ?? copy.detail}
             </div>
           </div>
           <div
@@ -186,16 +194,14 @@ function Actions({ args }: { args: Record<string, unknown> }) {
           >
             {pendingDecision === "denying" ? "Denying..." : "Deny"}
           </button>
-          {hasDetails ? (
-            <button
-              type="button"
-              onClick={openDetails}
-              className="inline-flex h-8 items-center justify-center gap-1 rounded-lg border border-border bg-transparent px-3 text-xs font-medium text-muted transition hover:bg-surface-2 hover:text-text"
-            >
-              {detailSheet.open && detailSheet.key === detailKey ? "Hide details" : "Details"}
-              <ChevronRightIcon width={14} height={14} />
-            </button>
-          ) : null}
+          <button
+            type="button"
+            onClick={openDetails}
+            className="inline-flex h-8 items-center justify-center gap-1 rounded-lg border border-border bg-transparent px-3 text-xs font-medium text-muted transition hover:bg-surface-2 hover:text-text"
+          >
+            {detailSheet.open && detailSheet.key === detailKey ? "Hide details" : "Details"}
+            <ChevronRightIcon width={14} height={14} />
+          </button>
         </div>
       </div>
     );

--- a/apps/web/components/assistant/workflow-todo-tool-ui.tsx
+++ b/apps/web/components/assistant/workflow-todo-tool-ui.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { makeAssistantToolUI, useAssistantState } from "@assistant-ui/react";
+import { makeAssistantToolUI } from "@assistant-ui/react";
 import { CheckIcon, ChevronRightIcon, Cross2Icon, DotFilledIcon } from "@radix-ui/react-icons";
 
-import { extractLatestCanonicalActionRequests } from "@/components/assistant/approval-state";
 import {
   toggleAssistantDetailSheet,
   useAssistantDetailSheet,
@@ -140,8 +139,6 @@ export function extractLatestWorkflowTodos(messages: unknown): WorkflowTodoItem[
 }
 
 export function WorkflowTodoCard({ todos }: { todos: WorkflowTodoItem[] }) {
-  const threadMessages = useAssistantState(({ thread }: any) => thread?.messages);
-  const hasApprovalHistory = (extractLatestCanonicalActionRequests(threadMessages) ?? []).length > 0;
   const detailSheet = useAssistantDetailSheet();
   const detailKey = `workflow:${todos.map((todo) => `${todo.content}:${todo.status}`).join("|")}`;
   const completedCount = todos.filter((todo) => todo.status === "completed").length;
@@ -150,25 +147,30 @@ export function WorkflowTodoCard({ todos }: { todos: WorkflowTodoItem[] }) {
     (todo) => todo.status === "completed" || todo.status === "cancelled",
   );
 
-  if (!todos.length || !isTerminal || hasApprovalHistory) {
+  if (!todos.length || !isTerminal) {
     return null;
   }
 
   const summaryParts = [
-    cancelledCount > 0 ? "Run ended" : "Completed",
+    cancelledCount > 0 ? "Ended" : "Completed",
     `${completedCount}/${todos.length} steps`,
+    cancelledCount > 0 ? `${cancelledCount} cancelled` : null,
   ].filter(Boolean);
+  const title = "Run summary";
+  const badge = cancelledCount > 0 ? "ended" : "done";
+  const badgeClassName =
+    cancelledCount > 0 ? "bg-slate-200/80 text-slate-800" : "bg-emerald-100/80 text-emerald-900";
 
   return (
     <div className="mt-3 rounded-lg border border-border/60 bg-bg/10 px-3 py-2">
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-sm text-text">Run details</div>
+          <div className="text-sm text-text">{title}</div>
           <div className="mt-1 text-xs text-muted">{summaryParts.join(" · ")}</div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <div className="rounded-full bg-emerald-100/80 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-emerald-900">
-            {cancelledCount > 0 ? "ended" : "done"}
+          <div className={["rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em]", badgeClassName].join(" ")}>
+            {badge}
           </div>
           <button
             type="button"
@@ -177,13 +179,10 @@ export function WorkflowTodoCard({ todos }: { todos: WorkflowTodoItem[] }) {
                 open: true,
                 key: detailKey,
                 kind: "workflow",
-                title: "Run details",
+                title,
                 subtitle: summaryParts.join(" · "),
-                badge: cancelledCount > 0 ? "ended" : "done",
-                badgeClassName:
-                  cancelledCount > 0
-                    ? "bg-slate-200/80 text-slate-800"
-                    : "bg-emerald-100/80 text-emerald-900",
+                badge,
+                badgeClassName,
                 todos,
               });
             }}

--- a/apps/web/components/claude/workflow-todo-tool-ui.test.tsx
+++ b/apps/web/components/claude/workflow-todo-tool-ui.test.tsx
@@ -5,12 +5,14 @@ const { mockToggleAssistantDetailSheet } = vi.hoisted(() => ({
   mockToggleAssistantDetailSheet: vi.fn(),
 }));
 
+let mockThreadMessages: any[] = [];
+
 vi.mock("@assistant-ui/react", () => ({
   makeAssistantToolUI: ({ render }: { render: (props: any) => unknown }) => render,
   useAssistantState: (selector: any) =>
     selector({
       thread: {
-        messages: [],
+        messages: mockThreadMessages,
       },
     }),
 }));
@@ -24,6 +26,8 @@ import { WorkflowTodoCard } from "@/components/claude/workflow-todo-tool-ui";
 
 describe("WorkflowTodoCard", () => {
   it("renders terminal workflow runs as compact details with expandable summary", () => {
+    mockThreadMessages = [];
+
     render(
       <WorkflowTodoCard
         todos={[
@@ -33,7 +37,7 @@ describe("WorkflowTodoCard", () => {
       />,
     );
 
-    expect(screen.getByText("Run details")).toBeVisible();
+    expect(screen.getByText("Run summary")).toBeVisible();
     expect(screen.getByText(/completed .* 2\/2 steps/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /details/i }));
@@ -42,8 +46,40 @@ describe("WorkflowTodoCard", () => {
       expect.objectContaining({
         open: true,
         kind: "workflow",
-        title: "Run details",
+        title: "Run summary",
       }),
     );
+  });
+
+  it("keeps the terminal workflow receipt visible when approval history exists", () => {
+    mockThreadMessages = [
+      {
+        metadata: {
+          custom: {
+            actionRequests: [
+              {
+                actionRequestId: "approval-1",
+                toolName: "whm_unsuspend_account",
+                risk: "CHANGE",
+                arguments: {},
+                status: "FINISHED",
+                lifecycleStatus: "finished",
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    render(
+      <WorkflowTodoCard
+        todos={[
+          { content: "Preflight", status: "completed", priority: "high" },
+          { content: "Apply change", status: "completed", priority: "high" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Run summary")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- keep approval cards as live-only controls while preserving richer overview details on demand
- make workflow terminal receipts the durable compact history surface, even for approval-backed runs
- polish workflow detail summaries and add coverage for the updated transcript behavior

## Verification
- npm test -- components/claude/request-approval-tool-ui.test.tsx components/claude/workflow-todo-tool-ui.test.tsx
- npm run build