### PR TITLE
feat(assistant): production-grade change receipts

### DIFF
--- a/apps/api/alembic/versions/0006_action_receipts.py
+++ b/apps/api/alembic/versions/0006_action_receipts.py
@@ -1,0 +1,84 @@
+"""action receipts
+
+Revision ID: 0006_action_receipts
+Revises: 0005_workflow_todo_statuses
+Create Date: 2026-03-19 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0006_action_receipts"
+down_revision: Union[str, None] = "0005_workflow_todo_statuses"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "action_receipts",
+        sa.Column(
+            "action_request_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("tool_run_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "schema_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("terminal_phase", sa.Text(), nullable=False),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["action_request_id"],
+            ["action_requests.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tool_run_id"],
+            ["tool_runs.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("action_request_id"),
+    )
+    op.create_index(
+        "ix_action_receipts_tool_run_id",
+        "action_receipts",
+        ["tool_run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_action_receipts_terminal_phase",
+        "action_receipts",
+        ["terminal_phase"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_action_receipts_created_at",
+        "action_receipts",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_action_receipts_created_at", table_name="action_receipts")
+    op.drop_index("ix_action_receipts_terminal_phase", table_name="action_receipts")
+    op.drop_index("ix_action_receipts_tool_run_id", table_name="action_receipts")
+    op.drop_table("action_receipts")

--- a/apps/api/src/noa_api/api/assistant/assistant_action_operations.py
+++ b/apps/api/src/noa_api/api/assistant/assistant_action_operations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from inspect import signature
 from typing import Any, Protocol, cast
 from uuid import UUID, uuid4
@@ -30,13 +31,21 @@ from noa_api.core.tool_error_sanitizer import SanitizedToolError, sanitize_tool_
 from noa_api.core.tools.argument_validation import validate_tool_arguments
 from noa_api.core.tools.registry import get_tool_definition
 from noa_api.core.workflows.registry import (
+    build_workflow_evidence_template,
     build_workflow_reply_template,
     build_workflow_todos,
     collect_recent_preflight_evidence,
     fetch_postflight_result,
     persist_workflow_todos,
 )
-from noa_api.core.workflows.types import render_workflow_reply_text
+from noa_api.core.workflows.types import (
+    workflow_evidence_template_payload,
+    workflow_reply_template_payload,
+)
+from noa_api.storage.postgres.action_receipts import (
+    ActionReceiptService,
+    SQLActionReceiptRepository,
+)
 from noa_api.storage.postgres.action_tool_runs import ActionToolRunService
 from noa_api.storage.postgres.lifecycle import ActionRequestStatus, ToolRisk
 from noa_api.storage.postgres.models import ActionRequest, ToolRun
@@ -75,6 +84,73 @@ async def _emit_update_workflow_todo_messages(
             )
         ],
     )
+
+
+async def _emit_workflow_receipt_messages(
+    *,
+    repository: AssistantMessageAuditRepositoryProtocol,
+    thread_id: UUID,
+    action_request_id: UUID,
+    payload: dict[str, object],
+) -> None:
+    tool_call_id = f"receipt-{action_request_id}"
+    await repository.create_message(
+        thread_id=thread_id,
+        role="assistant",
+        parts=[
+            {
+                "type": "tool-call",
+                "toolName": "workflow_receipt",
+                "toolCallId": tool_call_id,
+                "argsText": "Receipt",
+                "args": {"actionRequestId": str(action_request_id)},
+            }
+        ],
+    )
+    await repository.create_message(
+        thread_id=thread_id,
+        role="tool",
+        parts=[
+            build_tool_result_part(
+                tool_name="workflow_receipt",
+                tool_call_id=tool_call_id,
+                result=payload,
+                is_error=False,
+            )
+        ],
+    )
+
+
+def _build_change_receipt_v1(
+    *,
+    thread_id: UUID,
+    action_request_id: UUID,
+    tool_run_id: UUID | None,
+    tool_name: str,
+    workflow_family: str,
+    terminal_phase: str,
+    reply_template: dict[str, object] | None,
+    evidence_sections: list[dict[str, object]],
+    error_code: str | None = None,
+) -> dict[str, object]:
+    receipt_id = f"receipt-{action_request_id}"
+    generated_at = datetime.now(UTC).isoformat()
+    payload: dict[str, object] = {
+        "schemaVersion": 1,
+        "receiptId": receipt_id,
+        "threadId": str(thread_id),
+        "actionRequestId": str(action_request_id),
+        "toolRunId": str(tool_run_id) if tool_run_id is not None else None,
+        "toolName": tool_name,
+        "workflowFamily": workflow_family,
+        "terminalPhase": terminal_phase,
+        "generatedAt": generated_at,
+        "replyTemplate": reply_template,
+        "evidenceSections": evidence_sections,
+    }
+    if error_code is not None:
+        payload["errorCode"] = error_code
+    return payload
 
 
 class ApprovedToolExecutor(Protocol):
@@ -139,8 +215,16 @@ async def deny_action_request(
         raise action_request_not_found_error()
 
     tool = get_tool_definition(denied.tool_name)
-    reply_text: str | None = None
-    if tool is not None and tool.workflow_family is not None:
+    workflow_family: str | None = None
+    if tool is not None:
+        workflow_family = tool.workflow_family
+    should_create_workflow_receipt = (
+        workflow_family is not None and denied.risk == ToolRisk.CHANGE
+    )
+    receipt_payload: dict[str, object] | None = None
+    should_emit_receipt = False
+    if should_create_workflow_receipt:
+        assert workflow_family is not None
         working_messages = await _list_working_messages(
             repository=repository,
             thread_id=thread_id,
@@ -148,7 +232,7 @@ async def deny_action_request(
         preflight_evidence = collect_recent_preflight_evidence(working_messages)
         workflow_todos = build_workflow_todos(
             tool_name=denied.tool_name,
-            workflow_family=tool.workflow_family,
+            workflow_family=workflow_family,
             args=denied.args,
             phase="denied",
             preflight_evidence=preflight_evidence,
@@ -164,15 +248,63 @@ async def deny_action_request(
                 thread_id=thread_id,
                 todos=cast(list[dict[str, object]], workflow_todos),
             )
+
         reply_template = build_workflow_reply_template(
             tool_name=denied.tool_name,
-            workflow_family=tool.workflow_family,
+            workflow_family=workflow_family,
             args=denied.args,
             phase="denied",
             preflight_evidence=preflight_evidence,
         )
-        if reply_template is not None:
-            reply_text = render_workflow_reply_text(reply_template)
+        reply_payload = (
+            workflow_reply_template_payload(reply_template)
+            if reply_template is not None
+            else None
+        )
+        evidence_template = build_workflow_evidence_template(
+            tool_name=denied.tool_name,
+            workflow_family=workflow_family,
+            args=denied.args,
+            phase="denied",
+            preflight_evidence=preflight_evidence,
+        )
+        evidence_payload = (
+            workflow_evidence_template_payload(evidence_template)
+            if evidence_template is not None
+            else None
+        )
+        evidence_sections: list[dict[str, object]] = []
+        if evidence_payload is not None:
+            raw_sections = evidence_payload.get("evidenceSections")
+            if isinstance(raw_sections, list):
+                evidence_sections = [
+                    section for section in raw_sections if isinstance(section, dict)
+                ]
+
+        receipt_payload = _build_change_receipt_v1(
+            thread_id=thread_id,
+            action_request_id=denied.id,
+            tool_run_id=None,
+            tool_name=denied.tool_name,
+            workflow_family=workflow_family,
+            terminal_phase="denied",
+            reply_template=reply_payload,
+            evidence_sections=evidence_sections,
+        )
+        if session is not None:
+            receipt_service = ActionReceiptService(
+                repository=SQLActionReceiptRepository(session)
+            )
+            should_emit_receipt = (
+                await receipt_service.create_action_receipt_if_missing(
+                    action_request_id=denied.id,
+                    tool_run_id=None,
+                    terminal_phase="denied",
+                    payload=receipt_payload,
+                )
+            )
+        else:
+            should_emit_receipt = True
 
     with log_context(
         action_request_id=str(denied.id),
@@ -186,11 +318,19 @@ async def deny_action_request(
             parts=[
                 {
                     "type": "text",
-                    "text": reply_text
-                    or f"Denied action request for tool '{denied.tool_name}'.",
+                    "text": "Denied. Receipt below."
+                    if should_create_workflow_receipt
+                    else f"Denied action request for tool '{denied.tool_name}'.",
                 }
             ],
         )
+        if should_emit_receipt and receipt_payload is not None:
+            await _emit_workflow_receipt_messages(
+                repository=repository,
+                thread_id=thread_id,
+                action_request_id=denied.id,
+                payload=receipt_payload,
+            )
         await repository.create_audit_log(
             event_type="action_denied",
             actor_email=owner_user_email,
@@ -381,7 +521,7 @@ async def execute_approved_tool_run(
         session=session,
     )
     if preflight_error is not None:
-        workflow_reply_text = None
+        preflight_evidence: list[dict[str, object]] = []
         if tool.workflow_family is not None:
             working_messages = await _list_working_messages(
                 repository=repository,
@@ -407,15 +547,6 @@ async def execute_approved_tool_run(
                     thread_id=thread_id,
                     todos=cast(list[dict[str, object]], failed_todos),
                 )
-
-            workflow_reply_text = _workflow_reply_text(
-                tool_name=approved_request.tool_name,
-                workflow_family=tool.workflow_family,
-                args=approved_request.args,
-                phase="failed",
-                preflight_evidence=preflight_evidence,
-                error_code=preflight_error.error_code,
-            )
         await _persist_failed_tool_run(
             started_tool_run=started_tool_run,
             approved_request=approved_request,
@@ -425,7 +556,7 @@ async def execute_approved_tool_run(
             action_tool_run_service=action_tool_run_service,
             tool_run_error=preflight_error.error_code,
             tool_result=preflight_error.as_result(),
-            assistant_text=workflow_reply_text,
+            assistant_text=None,
             audit_metadata={
                 "thread_id": str(thread_id),
                 "tool_run_id": str(started_tool_run.id),
@@ -434,6 +565,71 @@ async def execute_approved_tool_run(
                 "error_code": preflight_error.error_code,
             },
         )
+        if tool.workflow_family is not None:
+            reply_template = build_workflow_reply_template(
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                args=approved_request.args,
+                phase="failed",
+                preflight_evidence=preflight_evidence,
+                error_code=preflight_error.error_code,
+            )
+            reply_payload = (
+                workflow_reply_template_payload(reply_template)
+                if reply_template is not None
+                else None
+            )
+            evidence_template = build_workflow_evidence_template(
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                args=approved_request.args,
+                phase="failed",
+                preflight_evidence=preflight_evidence,
+                error_code=preflight_error.error_code,
+            )
+            evidence_payload = (
+                workflow_evidence_template_payload(evidence_template)
+                if evidence_template is not None
+                else None
+            )
+            evidence_sections: list[dict[str, object]] = []
+            if evidence_payload is not None:
+                raw_sections = evidence_payload.get("evidenceSections")
+                if isinstance(raw_sections, list):
+                    evidence_sections = [
+                        section for section in raw_sections if isinstance(section, dict)
+                    ]
+            receipt_payload = _build_change_receipt_v1(
+                thread_id=thread_id,
+                action_request_id=approved_request.id,
+                tool_run_id=started_tool_run.id,
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                terminal_phase="failed",
+                reply_template=reply_payload,
+                evidence_sections=evidence_sections,
+                error_code=preflight_error.error_code,
+            )
+            should_emit_receipt = True
+            if session is not None:
+                receipt_service = ActionReceiptService(
+                    repository=SQLActionReceiptRepository(session)
+                )
+                should_emit_receipt = (
+                    await receipt_service.create_action_receipt_if_missing(
+                        action_request_id=approved_request.id,
+                        tool_run_id=started_tool_run.id,
+                        terminal_phase="failed",
+                        payload=receipt_payload,
+                    )
+                )
+            if should_emit_receipt:
+                await _emit_workflow_receipt_messages(
+                    repository=repository,
+                    thread_id=thread_id,
+                    action_request_id=approved_request.id,
+                    payload=receipt_payload,
+                )
         return
 
     working_messages = await _list_working_messages(
@@ -519,9 +715,8 @@ async def execute_approved_tool_run(
                 )
             ],
         )
-        workflow_reply_text = None
         if tool.workflow_family is not None:
-            workflow_reply_text = _workflow_reply_text(
+            reply_template = build_workflow_reply_template(
                 tool_name=approved_request.tool_name,
                 workflow_family=tool.workflow_family,
                 args=approved_request.args,
@@ -530,25 +725,63 @@ async def execute_approved_tool_run(
                 result=persisted_result,
                 postflight_result=postflight_result,
             )
-        suppressed_workflow_completion_message_families = {
-            "whm-account-lifecycle",
-            "whm-account-contact-email",
-            "whm-csf-batch-change",
-        }
-        should_persist_workflow_completion_message = (
-            tool.workflow_family is not None
-            and tool.workflow_family
-            not in suppressed_workflow_completion_message_families
-        )
-        if (
-            workflow_reply_text is not None
-            and should_persist_workflow_completion_message
-        ):
-            await repository.create_message(
-                thread_id=thread_id,
-                role="assistant",
-                parts=[{"type": "text", "text": workflow_reply_text}],
+            reply_payload = (
+                workflow_reply_template_payload(reply_template)
+                if reply_template is not None
+                else None
             )
+            evidence_template = build_workflow_evidence_template(
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                args=approved_request.args,
+                phase="completed",
+                preflight_evidence=preflight_evidence,
+                result=persisted_result,
+                postflight_result=postflight_result,
+            )
+            evidence_payload = (
+                workflow_evidence_template_payload(evidence_template)
+                if evidence_template is not None
+                else None
+            )
+            evidence_sections: list[dict[str, object]] = []
+            if evidence_payload is not None:
+                raw_sections = evidence_payload.get("evidenceSections")
+                if isinstance(raw_sections, list):
+                    evidence_sections = [
+                        section for section in raw_sections if isinstance(section, dict)
+                    ]
+            receipt_payload = _build_change_receipt_v1(
+                thread_id=thread_id,
+                action_request_id=approved_request.id,
+                tool_run_id=started_tool_run.id,
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                terminal_phase="completed",
+                reply_template=reply_payload,
+                evidence_sections=evidence_sections,
+            )
+            should_emit_receipt = True
+            if session is not None:
+                receipt_service = ActionReceiptService(
+                    repository=SQLActionReceiptRepository(session)
+                )
+                should_emit_receipt = (
+                    await receipt_service.create_action_receipt_if_missing(
+                        action_request_id=approved_request.id,
+                        tool_run_id=started_tool_run.id,
+                        terminal_phase="completed",
+                        payload=receipt_payload,
+                    )
+                )
+            if should_emit_receipt:
+                await _emit_workflow_receipt_messages(
+                    repository=repository,
+                    thread_id=thread_id,
+                    action_request_id=approved_request.id,
+                    payload=receipt_payload,
+                )
+
         await repository.create_audit_log(
             event_type="tool_completed",
             actor_email=owner_user_email,
@@ -594,16 +827,6 @@ async def execute_approved_tool_run(
                     thread_id=thread_id,
                     todos=cast(list[dict[str, object]], failed_todos),
                 )
-        workflow_reply_text = None
-        if tool.workflow_family is not None:
-            workflow_reply_text = _workflow_reply_text(
-                tool_name=approved_request.tool_name,
-                workflow_family=tool.workflow_family,
-                args=approved_request.args,
-                phase="failed",
-                preflight_evidence=preflight_evidence,
-                error_code=sanitized_error.error_code,
-            )
         await _persist_failed_tool_run(
             started_tool_run=started_tool_run,
             approved_request=approved_request,
@@ -613,7 +836,7 @@ async def execute_approved_tool_run(
             action_tool_run_service=action_tool_run_service,
             tool_run_error=sanitized_error.error_code,
             tool_result=cast(dict[str, object], sanitized_error.as_result()),
-            assistant_text=workflow_reply_text,
+            assistant_text=None,
             audit_metadata={
                 "thread_id": str(thread_id),
                 "tool_run_id": str(started_tool_run.id),
@@ -622,6 +845,72 @@ async def execute_approved_tool_run(
                 "error_code": sanitized_error.error_code,
             },
         )
+
+        if tool.workflow_family is not None:
+            reply_template = build_workflow_reply_template(
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                args=approved_request.args,
+                phase="failed",
+                preflight_evidence=preflight_evidence,
+                error_code=sanitized_error.error_code,
+            )
+            reply_payload = (
+                workflow_reply_template_payload(reply_template)
+                if reply_template is not None
+                else None
+            )
+            evidence_template = build_workflow_evidence_template(
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                args=approved_request.args,
+                phase="failed",
+                preflight_evidence=preflight_evidence,
+                error_code=sanitized_error.error_code,
+            )
+            evidence_payload = (
+                workflow_evidence_template_payload(evidence_template)
+                if evidence_template is not None
+                else None
+            )
+            evidence_sections: list[dict[str, object]] = []
+            if evidence_payload is not None:
+                raw_sections = evidence_payload.get("evidenceSections")
+                if isinstance(raw_sections, list):
+                    evidence_sections = [
+                        section for section in raw_sections if isinstance(section, dict)
+                    ]
+            receipt_payload = _build_change_receipt_v1(
+                thread_id=thread_id,
+                action_request_id=approved_request.id,
+                tool_run_id=started_tool_run.id,
+                tool_name=approved_request.tool_name,
+                workflow_family=tool.workflow_family,
+                terminal_phase="failed",
+                reply_template=reply_payload,
+                evidence_sections=evidence_sections,
+                error_code=sanitized_error.error_code,
+            )
+            should_emit_receipt = True
+            if session is not None:
+                receipt_service = ActionReceiptService(
+                    repository=SQLActionReceiptRepository(session)
+                )
+                should_emit_receipt = (
+                    await receipt_service.create_action_receipt_if_missing(
+                        action_request_id=approved_request.id,
+                        tool_run_id=started_tool_run.id,
+                        terminal_phase="failed",
+                        payload=receipt_payload,
+                    )
+                )
+            if should_emit_receipt:
+                await _emit_workflow_receipt_messages(
+                    repository=repository,
+                    thread_id=thread_id,
+                    action_request_id=approved_request.id,
+                    payload=receipt_payload,
+                )
 
 
 async def _validate_approved_tool_preflight(
@@ -685,32 +974,6 @@ async def _execute_tool(
     if execute_kwargs is not args:
         return await tool.execute(**execute_kwargs)
     return await tool.execute(**args)
-
-
-def _workflow_reply_text(
-    *,
-    tool_name: str,
-    workflow_family: str,
-    args: dict[str, object],
-    phase: str,
-    preflight_evidence: list[dict[str, object]],
-    result: dict[str, object] | None = None,
-    postflight_result: dict[str, object] | None = None,
-    error_code: str | None = None,
-) -> str | None:
-    reply_template = build_workflow_reply_template(
-        tool_name=tool_name,
-        workflow_family=workflow_family,
-        args=args,
-        phase=phase,
-        preflight_evidence=preflight_evidence,
-        result=result,
-        postflight_result=postflight_result,
-        error_code=error_code,
-    )
-    if reply_template is None:
-        return None
-    return render_workflow_reply_text(reply_template)
 
 
 async def _persist_failed_tool_run(

--- a/apps/api/src/noa_api/core/prompts/noa-system-prompt.md
+++ b/apps/api/src/noa_api/core/prompts/noa-system-prompt.md
@@ -78,6 +78,7 @@ Response contract
 - For READ results: give the direct answer first, then the supporting evidence.
 - For CHANGE proposals before approval: include what will change, why, evidence from preflight, and what success looks like.
 - After CHANGE execution: state whether the outcome was changed, no-op, partial failure, or failed; include the evidence or postflight result; then give the next safe step.
+- If a workflow receipt card is present in the thread (toolName `workflow_receipt`), keep completion narration to 1-2 lines, no tables or JSON, and defer details to the receipt (prefer: "See receipt above."). If the outcome is partial failure or failed and the reply template provides a next safe step, include it in one sentence.
 - If workflow-family reply template data is present, preserve its semantics and keep the ordering outcome first, evidence second, next safe step last.
 
 Response style

--- a/apps/api/src/noa_api/storage/postgres/action_receipts.py
+++ b/apps/api/src/noa_api/storage/postgres/action_receipts.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Protocol
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from noa_api.core.json_safety import json_safe
+from noa_api.storage.postgres.models import ActionReceipt
+
+
+class ActionReceiptRepositoryProtocol(Protocol):
+    async def get_by_action_request_id(
+        self, *, action_request_id: UUID
+    ) -> ActionReceipt | None: ...
+
+    async def create_action_receipt_if_missing(
+        self,
+        *,
+        action_request_id: UUID,
+        tool_run_id: UUID | None,
+        schema_version: int,
+        terminal_phase: str,
+        payload: dict[str, object],
+    ) -> bool: ...
+
+
+class SQLActionReceiptRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_action_request_id(
+        self, *, action_request_id: UUID
+    ) -> ActionReceipt | None:
+        result = await self._session.execute(
+            select(ActionReceipt).where(
+                ActionReceipt.action_request_id == action_request_id
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_action_receipt_if_missing(
+        self,
+        *,
+        action_request_id: UUID,
+        tool_run_id: UUID | None,
+        schema_version: int,
+        terminal_phase: str,
+        payload: dict[str, object],
+    ) -> bool:
+        safe_payload = json_safe(payload)
+        payload_obj = (
+            safe_payload if isinstance(safe_payload, dict) else {"value": safe_payload}
+        )
+
+        stmt = (
+            insert(ActionReceipt)
+            .values(
+                action_request_id=action_request_id,
+                tool_run_id=tool_run_id,
+                schema_version=schema_version,
+                terminal_phase=terminal_phase,
+                payload=payload_obj,
+                created_at=datetime.now(UTC),
+            )
+            .on_conflict_do_nothing(index_elements=["action_request_id"])
+            .returning(ActionReceipt.action_request_id)
+        )
+        result = await self._session.execute(stmt)
+        created = result.scalar_one_or_none() is not None
+        if created:
+            await self._session.flush()
+        return created
+
+
+class ActionReceiptService:
+    def __init__(self, *, repository: ActionReceiptRepositoryProtocol) -> None:
+        self._repository = repository
+
+    async def create_action_receipt_if_missing(
+        self,
+        *,
+        action_request_id: UUID,
+        tool_run_id: UUID | None,
+        terminal_phase: str,
+        payload: dict[str, object],
+        schema_version: int = 1,
+    ) -> bool:
+        return await self._repository.create_action_receipt_if_missing(
+            action_request_id=action_request_id,
+            tool_run_id=tool_run_id,
+            schema_version=schema_version,
+            terminal_phase=terminal_phase,
+            payload=payload,
+        )

--- a/apps/api/src/noa_api/storage/postgres/models.py
+++ b/apps/api/src/noa_api/storage/postgres/models.py
@@ -289,6 +289,31 @@ class ToolRun(Base):
     )
 
 
+class ActionReceipt(Base):
+    __tablename__ = "action_receipts"
+
+    action_request_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("action_requests.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    tool_run_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("tool_runs.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    schema_version: Mapped[int] = mapped_column(
+        nullable=False,
+        server_default="1",
+    )
+    terminal_phase: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    payload: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), index=True
+    )
+
+
 class WHMServer(Base):
     __tablename__ = "whm_servers"
 

--- a/apps/web/components/assistant/approval-lifecycle-ui.ts
+++ b/apps/web/components/assistant/approval-lifecycle-ui.ts
@@ -35,7 +35,7 @@ export function getApprovalLifecyclePresentation(
         title: "Approval recorded",
         detail: "The request is approved and about to execute.",
         badge: "approved",
-        badgeClassName: "bg-emerald-100/80 text-emerald-900",
+        badgeClassName: "bg-emerald-500/10 text-emerald-200 ring-1 ring-emerald-500/25",
         Icon: CheckIcon,
       };
     case "executing":
@@ -43,7 +43,7 @@ export function getApprovalLifecyclePresentation(
         title: "Applying approved change",
         detail: "NOA is running the approved change now.",
         badge: "running",
-        badgeClassName: "bg-sky-100/80 text-sky-900",
+        badgeClassName: "bg-sky-500/10 text-sky-200 ring-1 ring-sky-500/25",
         Icon: RocketIcon,
       };
     case "finished":
@@ -51,7 +51,7 @@ export function getApprovalLifecyclePresentation(
         title: "Change complete",
         detail: "Execution finished. Review the outcome in the thread.",
         badge: "done",
-        badgeClassName: "bg-emerald-100/80 text-emerald-900",
+        badgeClassName: "bg-emerald-500/10 text-emerald-200 ring-1 ring-emerald-500/25",
         Icon: CheckIcon,
       };
     case "failed":
@@ -59,7 +59,7 @@ export function getApprovalLifecyclePresentation(
         title: "Change failed",
         detail: "The approval succeeded, but the execution did not finish cleanly.",
         badge: "failed",
-        badgeClassName: "bg-rose-100/80 text-rose-900",
+        badgeClassName: "bg-rose-500/10 text-rose-200 ring-1 ring-rose-500/25",
         Icon: Cross2Icon,
       };
     case "denied":
@@ -67,7 +67,7 @@ export function getApprovalLifecyclePresentation(
         title: "Change denied",
         detail: "Execution stops and the request is now terminal.",
         badge: "denied",
-        badgeClassName: "bg-slate-200/80 text-slate-800",
+        badgeClassName: "bg-slate-500/10 text-slate-200 ring-1 ring-slate-500/25",
         Icon: Cross2Icon,
       };
   }

--- a/apps/web/components/assistant/claude-workspace.tsx
+++ b/apps/web/components/assistant/claude-workspace.tsx
@@ -8,6 +8,7 @@ import { AssistantDetailSheet } from "@/components/assistant/assistant-detail-sh
 import { ClaudeThread } from "@/components/assistant/claude-thread";
 import { ClaudeThreadList } from "@/components/assistant/claude-thread-list";
 import { RequestApprovalToolUI } from "@/components/assistant/request-approval-tool-ui";
+import { WorkflowReceiptToolUI } from "@/components/assistant/workflow-receipt-tool-ui";
 import { WorkflowTodoToolUI } from "@/components/assistant/workflow-todo-tool-ui";
 
 export function ClaudeWorkspace() {
@@ -45,6 +46,7 @@ export function ClaudeWorkspace() {
       <section className="relative h-dvh w-full overflow-hidden bg-bg">
         <RequestApprovalToolUI />
         <WorkflowTodoToolUI />
+        <WorkflowReceiptToolUI />
         <AssistantDetailSheet />
 
         <div

--- a/apps/web/components/assistant/workflow-receipt-tool-ui.tsx
+++ b/apps/web/components/assistant/workflow-receipt-tool-ui.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { makeAssistantToolUI } from "@assistant-ui/react";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
+
+import {
+  toggleAssistantDetailSheet,
+  useAssistantDetailSheet,
+} from "@/components/assistant/assistant-detail-sheet-store";
+
+type ReceiptOutcome = "changed" | "partial" | "no_op" | "failed" | "denied" | "info";
+
+type ReceiptBadge = {
+  label: "SUCCESS" | "PARTIAL" | "NO-OP" | "FAILED" | "DENIED";
+  className: string;
+};
+
+type ReceiptReplyTemplate = {
+  title: string;
+  outcome: ReceiptOutcome;
+  summary: string;
+  nextStep?: string | null;
+};
+
+type ReceiptEvidenceItem = {
+  label: string;
+  value: string;
+};
+
+type ReceiptEvidenceSection = {
+  key?: string;
+  title: string;
+  items: ReceiptEvidenceItem[];
+};
+
+function coerceString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function coerceRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function coerceReplyTemplate(value: unknown): ReceiptReplyTemplate | undefined {
+  const record = coerceRecord(value);
+  const title = coerceString(record?.title);
+  const summary = coerceString(record?.summary);
+  const outcome = coerceString(record?.outcome);
+  const nextStep = coerceString(record?.nextStep);
+
+  const isOutcome =
+    outcome === "changed" ||
+    outcome === "partial" ||
+    outcome === "no_op" ||
+    outcome === "failed" ||
+    outcome === "denied" ||
+    outcome === "info";
+
+  if (!title || !summary || !isOutcome) return undefined;
+
+  return {
+    title,
+    summary,
+    outcome,
+    nextStep: nextStep ?? null,
+  };
+}
+
+function coerceEvidenceSections(value: unknown): ReceiptEvidenceSection[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const record = coerceRecord(entry);
+    const title = coerceString(record?.title);
+    const key = coerceString(record?.key);
+    const items = Array.isArray(record?.items)
+      ? record.items
+          .map((item) => {
+            const itemRecord = coerceRecord(item);
+            const label = coerceString(itemRecord?.label);
+            const rawValue = itemRecord?.value;
+            if (!label) return undefined;
+            if (typeof rawValue === "string") return { label, value: rawValue };
+            if (typeof rawValue === "number" || typeof rawValue === "boolean") {
+              return { label, value: String(rawValue) };
+            }
+            return undefined;
+          })
+          .filter((item): item is ReceiptEvidenceItem => Boolean(item))
+      : [];
+    if (!title || items.length === 0) return [];
+    return [{ key, title, items }];
+  });
+}
+
+function normalizeText(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function includesLoose(haystack: string, needle: string): boolean {
+  return normalizeText(haystack).includes(normalizeText(needle));
+}
+
+function getBadge(outcome: ReceiptOutcome): ReceiptBadge {
+  switch (outcome) {
+    case "changed":
+      return {
+        label: "SUCCESS",
+        className: "bg-emerald-500/10 text-emerald-200 ring-1 ring-emerald-500/25",
+      };
+    case "partial":
+      return {
+        label: "PARTIAL",
+        className: "bg-amber-500/10 text-amber-200 ring-1 ring-amber-500/25",
+      };
+    case "no_op":
+    case "info":
+      return {
+        label: "NO-OP",
+        className: "bg-surface-2 text-muted ring-1 ring-border/40",
+      };
+    case "failed":
+      return {
+        label: "FAILED",
+        className: "bg-rose-500/10 text-rose-200 ring-1 ring-rose-500/25",
+      };
+    case "denied":
+      return {
+        label: "DENIED",
+        className: "bg-slate-500/10 text-slate-200 ring-1 ring-slate-500/25",
+      };
+  }
+}
+
+function getPreviewSections(sections: ReceiptEvidenceSection[]) {
+  const requested =
+    sections.find((section) => section.key === "requested_change") ??
+    sections.find((section) => includesLoose(section.title, "requested"));
+  const verification =
+    sections.find((section) => section.key === "verification") ??
+    sections.find((section) => includesLoose(section.title, "verification"));
+
+  const nonEmpty = sections.filter((section) => section.items.length > 0);
+  const change = requested ?? nonEmpty[0];
+  const verificationFallback = nonEmpty.find((section) => section !== change) ?? nonEmpty[1];
+  const verify = verification ?? verificationFallback;
+
+  return { change, verify };
+}
+
+function clampStyle(lines: number) {
+  return {
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical" as const,
+    WebkitLineClamp: lines,
+    overflow: "hidden",
+  };
+}
+
+function buildReceiptPlaintext(payload: {
+  title: string;
+  badge: ReceiptBadge;
+  summary: string;
+  actionRequestId?: string;
+  toolRunId?: string;
+  receiptId?: string;
+  evidenceSections: ReceiptEvidenceSection[];
+  nextStep?: string | null;
+}) {
+  const lines: string[] = [];
+  lines.push(payload.title);
+  lines.push(`Status: ${payload.badge.label}`);
+  lines.push("");
+  lines.push(payload.summary);
+  lines.push("");
+
+  for (const section of payload.evidenceSections) {
+    lines.push(`${section.title}:`);
+    for (const item of section.items) {
+      lines.push(`- ${item.label}: ${item.value}`);
+    }
+    lines.push("");
+  }
+
+  if (payload.nextStep && payload.nextStep.trim()) {
+    lines.push(`Next step: ${payload.nextStep.trim()}`);
+    lines.push("");
+  }
+
+  if (payload.actionRequestId) lines.push(`Action ID: ${payload.actionRequestId}`);
+  if (payload.toolRunId) lines.push(`Tool run ID: ${payload.toolRunId}`);
+  if (payload.receiptId) lines.push(`Receipt ID: ${payload.receiptId}`);
+
+  return lines.join("\n").trim();
+}
+
+function ReceiptCard({ payload }: { payload: Record<string, unknown> }) {
+  const detailSheet = useAssistantDetailSheet();
+  const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+  const replyTemplate = coerceReplyTemplate(payload.replyTemplate);
+  const evidenceSections = useMemo(
+    () => coerceEvidenceSections(payload.evidenceSections),
+    [payload.evidenceSections],
+  );
+
+  const actionRequestId = coerceString(payload.actionRequestId);
+  const toolRunId = coerceString(payload.toolRunId);
+  const receiptId = coerceString(payload.receiptId);
+  const toolName = coerceString(payload.toolName);
+
+  if (!replyTemplate) {
+    return (
+      <div className="mt-3 rounded-xl border border-border bg-surface/70 p-3 text-sm text-muted">
+        Workflow receipt unavailable.
+      </div>
+    );
+  }
+
+  const badge = getBadge(replyTemplate.outcome);
+  const detailKey = `receipt:${receiptId ?? toolRunId ?? actionRequestId ?? replyTemplate.title}`;
+  const sectionsForDetail = [
+    {
+      title: "Overview",
+      items: [
+        { label: "Status", value: badge.label },
+        { label: "Tool", value: toolName ?? "workflow_receipt" },
+        { label: "Action ID", value: actionRequestId ?? "" },
+        { label: "Tool run ID", value: toolRunId ?? "" },
+      ].filter((item) => item.value.trim().length > 0),
+    },
+    ...evidenceSections.map((section) => ({ title: section.title, items: section.items })),
+  ].filter((section) => section.items.length > 0);
+
+  const { change, verify } = useMemo(() => getPreviewSections(evidenceSections), [evidenceSections]);
+  const changeItems = change?.items.slice(0, 2) ?? [];
+  const verifyItems = verify?.items.slice(0, 2) ?? [];
+  const shownCount = changeItems.length + verifyItems.length;
+  const totalCount = evidenceSections.reduce((sum, section) => sum + section.items.length, 0);
+  const moreCount = Math.max(0, totalCount - shownCount);
+
+  const openDetails = () => {
+    toggleAssistantDetailSheet({
+      open: true,
+      key: detailKey,
+      kind: "approval",
+      title: replyTemplate.title,
+      subtitle: replyTemplate.summary,
+      badge: badge.label,
+      badgeClassName: badge.className,
+      sections: sectionsForDetail,
+    });
+  };
+
+  const canClipboard =
+    typeof window !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    Boolean(navigator.clipboard?.writeText);
+
+  const copyReceipt = async () => {
+    if (!canClipboard) return;
+    try {
+      await navigator.clipboard.writeText(
+        buildReceiptPlaintext({
+          title: replyTemplate.title,
+          badge,
+          summary: replyTemplate.summary,
+          actionRequestId,
+          toolRunId,
+          receiptId,
+          evidenceSections,
+          nextStep: replyTemplate.nextStep,
+        }),
+      );
+      setCopyState("copied");
+      window.setTimeout(() => setCopyState("idle"), 1400);
+    } catch {
+      // no-op
+    }
+  };
+
+  const renderPreviewBlock = (
+    title: string,
+    items: ReceiptEvidenceItem[],
+  ) => {
+    if (items.length === 0) return null;
+    return (
+      <div className="rounded-lg border border-border/60 bg-bg/25 px-3 py-2">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted">
+          {title}
+        </div>
+        <div className="mt-2 space-y-1.5">
+          {items.map((item) => (
+            <div key={`${title}-${item.label}-${item.value}`} className="min-w-0 text-xs text-muted">
+              <span className="font-medium text-text">{item.label}</span>
+              <span className="text-muted">: </span>
+              <span className="break-words" style={clampStyle(1)}>
+                {item.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="mt-3 rounded-2xl border border-border/60 bg-bg/10 px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold text-text">{replyTemplate.title}</div>
+        </div>
+        <div
+          className={[
+            "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em]",
+            badge.className,
+          ].join(" ")}
+        >
+          {badge.label}
+        </div>
+      </div>
+
+      <div className="mt-1 text-xs text-muted" style={clampStyle(2)}>
+        {replyTemplate.summary}
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {renderPreviewBlock("Change", changeItems)}
+        {renderPreviewBlock("Verification", verifyItems)}
+        {moreCount > 0 ? (
+          <div className="px-1 text-[11px] text-muted">+{moreCount} more</div>
+        ) : null}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={openDetails}
+          className="inline-flex h-8 items-center justify-center gap-1 rounded-lg border border-border bg-transparent px-3 text-xs font-medium text-muted transition hover:bg-surface-2 hover:text-text"
+        >
+          {detailSheet.open && detailSheet.key === detailKey ? "Hide details" : "Details"}
+          <ChevronRightIcon width={14} height={14} />
+        </button>
+        <button
+          type="button"
+          onClick={copyReceipt}
+          disabled={!canClipboard}
+          className="inline-flex h-8 items-center justify-center rounded-lg bg-accent px-3 text-xs font-medium text-white transition-colors hover:bg-accent/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {copyState === "copied" ? "Copied" : "Copy receipt"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export const WorkflowReceiptToolUI = makeAssistantToolUI({
+  toolName: "workflow_receipt",
+  render: ({
+    args,
+    result,
+  }: {
+    args: Record<string, unknown>;
+    result?: unknown;
+    status?: unknown;
+  }) => {
+    const payload = coerceRecord(result) ?? args;
+    return <ReceiptCard payload={payload} />;
+  },
+});

--- a/docs/new.md
+++ b/docs/new.md
@@ -1,0 +1,312 @@
+# Change Receipts (Issues #26-#29) - Comprehensive Implementation Plan (Draft)
+
+Last updated: 2026-03-19
+
+This document is a brainstorming + implementation plan for:
+- #26 RFC: production-grade change receipts
+- #27 API: persist completed-phase receipt payload
+- #28 Web: render screenshot-friendly completion receipt
+- #29 Agent: standardize CHANGE completion narration
+
+Issue links:
+- https://github.com/rendyuwu/noa/issues/26
+- https://github.com/rendyuwu/noa/issues/27
+- https://github.com/rendyuwu/noa/issues/28
+- https://github.com/rendyuwu/noa/issues/29
+
+Related references:
+- `docs/assistant/workflow-templates.md`
+- `docs/assistant/whm-suspend-unsuspend.md`
+
+## 1) Problem Statement
+
+Current ToolRisk.CHANGE workflow completions are inconsistent and often not screenshot-friendly on mobile:
+- completion text can be long, redundant, and sometimes includes raw JSON/evidence dumps
+- web UI has multiple "completion-ish" surfaces (approval lifecycle, run summary, assistant message) that can compete
+- deterministic UI rendering is hard without a stable terminal-phase payload
+
+## 2) Goals / Non-Goals
+
+Goals:
+- A single, compact, mobile-screenshot-friendly receipt card for every terminal CHANGE outcome.
+- Receipt renders deterministically from structured data (not from LLM-authored markdown).
+- Human-only default: no raw JSON in the normal user flow.
+- Minimal assistant completion narration (1-2 lines) that does not duplicate the receipt.
+- Bind receipts to the correct run in threads with multiple actions.
+- Start with workflow-backed CHANGE tools (WHM families), then generalize.
+
+Scope (v1):
+- Workflow-backed ToolRisk.CHANGE tools, starting with WHM families called out in #27:
+  - `whm-account-lifecycle`
+  - `whm-account-contact-email`
+  - `whm-csf-batch-change`
+
+Non-goals (for v1):
+- A full audit log viewer UI (separate admin surface can come later).
+- Streaming live-updating receipts while executing (run summary/todos remain for progress).
+- Building new workflow families (we only standardize terminal receipts for existing ones).
+
+## 3) Current System Notes (What Exists Today)
+
+Backend structure already close to the desired contract:
+- Workflow template contract and payload helpers exist in `apps/api/src/noa_api/core/workflows/types.py`:
+  - `WorkflowReplyTemplate` -> `workflow_reply_template_payload(...)` (camelCase fields: `evidenceSummary`, `nextStep`, `assistantHint`)
+  - `WorkflowEvidenceTemplate` -> `workflow_evidence_template_payload(...)` (`evidenceSections[]` with `{ key, title, items[] }`)
+- Approval-time context is assembled in `apps/api/src/noa_api/core/workflows/registry.py` via `build_approval_context(...)`:
+  - already emits `replyTemplate`, `evidenceSections` (preferred), and a `beforeState` fallback
+
+Terminal-phase gap today:
+- Persistent "terminal truth" is mostly `tool_runs.status/result/error` in `apps/api/src/noa_api/storage/postgres/models.py`.
+- Workflow todo persistence is todo-only (`apps/api/src/noa_api/storage/postgres/workflow_todos.py`), not evidence-rich.
+
+Web already has evidence-capable UI primitives:
+- Approval cards render from `request_approval` args and can display evidence sections (`apps/web/components/assistant/request-approval-tool-ui.tsx`).
+- A generic detail sheet can render structured sections (`apps/web/components/assistant/assistant-detail-sheet.tsx`).
+- Workflow/run summary UI exists (`apps/web/components/assistant/workflow-todo-tool-ui.tsx`) but backend currently provides only `todos` on `update_workflow_todo`.
+
+## 4) Target UX (What Users See)
+
+For each terminal CHANGE outcome (SUCCESS/PARTIAL/NO-OP/FAILED/DENIED), the thread should show:
+1) A short assistant completion message (1-2 lines) that points to the receipt card.
+2) A Receipt Card UI immediately below (primary artifact).
+
+Receipt Card properties:
+- Always shows: title + status badge + one-paragraph outcome.
+- Shows compact Change + Verification previews (small key/value rows).
+- Optional "Details" opens the existing detail sheet for full evidence sections (still human-only).
+- No raw JSON in the normal card or detail sheet.
+
+Acceptance criteria (v1):
+- Every terminal CHANGE workflow run produces exactly one receipt card in the thread.
+- Receipt card fits in a single mobile screenshot in its default (collapsed) state.
+- No raw JSON is shown in normal user flow (card + details).
+- DENIED path still produces a receipt (even without a tool run).
+
+## 5) Deterministic Receipt Data Contract
+
+### 5.1 Reuse existing workflow payload shapes
+
+From `apps/api/src/noa_api/core/workflows/types.py`:
+- `replyTemplate` payload:
+  - `title: string`
+  - `outcome: "info"|"changed"|"no_op"|"partial"|"failed"|"denied"`
+  - `summary: string`
+  - `evidenceSummary: string[]`
+  - `nextStep?: string | null`
+  - `assistantHint?: string | null`
+- `evidenceSections` payload:
+  - `[{ key: string, title: string, items: [{ label: string, value: string }] }]`
+
+Section keys to treat as canonical (already documented in `docs/assistant/workflow-templates.md`):
+- `before_state`, `requested_change`, `after_state`, `verification`, `outcomes`, `failure`
+
+### 5.2 Receipt envelope (binding + versioning)
+
+To reliably bind a receipt to a specific action/run and to allow schema evolution, wrap the above in a small envelope.
+
+Proposed `ChangeReceiptV1` (human-only payload):
+```json
+{
+  "schemaVersion": 1,
+  "receiptId": "<uuid-or-stable-id>",
+  "threadId": "<uuid>",
+  "actionRequestId": "<uuid>",
+  "toolRunId": "<uuid-or-null>",
+  "toolName": "whm_suspend_account",
+  "workflowFamily": "whm-account-lifecycle",
+  "terminalPhase": "completed|failed|denied",
+  "generatedAt": "2026-03-19T12:34:56Z",
+  "replyTemplate": { "title": "...", "outcome": "changed", "summary": "...", "evidenceSummary": [] },
+  "evidenceSections": [{ "key": "requested_change", "title": "Requested change", "items": [{ "label": "Action", "value": "Suspend" }] }]
+}
+```
+
+Binding invariants:
+- `actionRequestId` always present.
+- `toolRunId` required for `completed|failed`, null for `denied`.
+- Receipts are immutable once persisted (web renders from persisted payload only).
+
+### 5.3 Status mapping (UI badge)
+
+Map `replyTemplate.outcome` to receipt badge:
+- `changed` -> `SUCCESS`
+- `partial` -> `PARTIAL`
+- `no_op` -> `NO-OP`
+- `failed` -> `FAILED`
+- `denied` -> `DENIED`
+- `info` -> (should not occur at terminal; treat as `NO-OP` or `SUCCESS` by policy)
+
+## 6) Backend Plan (apps/api)
+
+### 6.1 Generate terminal receipts from workflow templates
+
+Implementation goal: build the same structured payload at terminal phases that we already have at approval-time.
+
+Where the data comes from:
+- `replyTemplate`: `build_workflow_reply_template(...)`
+- `evidenceSections`: `build_workflow_evidence_template(...)` -> `workflow_evidence_template_payload(...)`
+- Preflight evidence: `collect_recent_preflight_evidence(...)` (already in `apps/api/src/noa_api/core/workflows/types.py`)
+- Postflight evidence (when available): `WorkflowTemplate.fetch_postflight_result(...)`
+
+Receipt creation should happen deterministically in the approval executor paths, not in LLM narration.
+
+### 6.2 Persist receipt payload (#27)
+
+Recommended persistence model: dedicated table (queryable + immutable + decoupled from raw tool output).
+
+Proposed DB change:
+- New table `action_receipts` keyed by `action_requests.id`.
+  - `action_request_id` UUID PK / FK
+  - `tool_run_id` UUID nullable
+  - `schema_version` int
+  - `terminal_phase` text
+  - `payload` JSONB
+  - `created_at` timestamptz
+
+Alternative (lower migration footprint, higher coupling):
+- Store receipt under `tool_runs.result.receipt` and/or `action_requests.args.receipt`.
+Tradeoff: mixes "raw tool output" with "human receipt payload", and makes future querying/backfill harder.
+
+Idempotency:
+- DB uniqueness should prevent duplicates (one receipt per action request / tool run).
+- Terminal handlers should treat receipt creation as create-once.
+
+### 6.3 Emit a receipt card into the thread (#26/#28)
+
+We need a deterministic artifact in the thread that the web can render as a card.
+
+Recommended transport:
+- Emit an internal tool-call message part at terminal time:
+  - `toolName: "workflow_receipt"`
+  - `args: ChangeReceiptV1`
+This makes the receipt appear in the thread without relying on assistant markdown.
+
+Alternative transport:
+- Extend `update_workflow_todo` tool-call payload to include `replyTemplate + evidenceSections` and render a receipt from that.
+Tradeoff: conflates progress/todos with terminal receipts and can be confusing in multi-run threads.
+
+### 6.4 Terminal phase coverage (completed / failed / denied)
+
+Terminal events to handle:
+- `completed`: after tool execution result persisted + postflight evidence fetched.
+- `failed`: after tool run marked failed; include failure evidence section.
+- `denied`: no tool run; still emit receipt (and minimal assistant message) because the agent does not rerun on deny.
+
+Likely touch points (for later implementation):
+- `apps/api/src/noa_api/api/assistant/assistant_action_operations.py`
+- `apps/api/src/noa_api/core/workflows/registry.py`
+
+## 7) Web Plan (apps/web)
+
+### 7.1 Receipt Card UI (#28)
+
+Implement a dedicated tool UI for `workflow_receipt` that renders the compact receipt card.
+
+Recommended architecture:
+- New tool UI component (tool-to-UI binding):
+  - `apps/web/components/assistant/workflow-receipt-tool-ui.tsx` (new)
+- Presentational card component:
+  - `apps/web/components/assistant/change-receipt-card.tsx` (new)
+- Reuse detail sheet for "Details":
+  - `apps/web/components/assistant/assistant-detail-sheet.tsx`
+
+Receipt layout rules (mobile-first, screenshot-safe):
+- Header: 1-line title + status badge; optional status rail.
+- Outcome: always visible, 2-line clamp.
+- Compact previews:
+  - "Change": up to 2 key/value rows
+  - "Verification": up to 2 key/value rows
+- Footer actions: `Details` + `Copy receipt`.
+- Expanded content (if any) should prefer the detail sheet over a tall in-thread card.
+
+Concrete UI spec (v1):
+- Container: full width of chat column; rounded corners; subtle border/shadow; optional 4px status rail.
+- Header (max 1 row):
+  - Left: small "RECEIPT" label.
+  - Title: 1-line truncation.
+  - Right: status badge: `SUCCESS | PARTIAL | NO-OP | FAILED | DENIED`.
+- Outcome (always visible; max 2 lines):
+  - One-sentence outcome; for FAILED/DENIED append a short reason if available.
+- Evidence preview (always visible; max 4 rows total):
+  - Two blocks: "Change" (up to 2 items) and "Verification" (up to 2 items).
+  - If more evidence exists: show a "+N more" hint that Details contains the rest.
+- Footer (max 1 row):
+  - Actions: `Details` (opens the detail sheet) + `Copy receipt` (plain text; no JSON).
+- Accessibility:
+  - Status must be conveyed by text, not color only.
+  - "Details" uses proper dialog semantics; toggles use `aria-expanded` when applicable.
+
+### 7.2 Deterministic rendering + run binding
+
+Rendering must depend only on the receipt payload:
+- stable section ordering comes from API
+- stable React keys derive from `receiptId`
+- guard multi-run threads by using `actionRequestId/toolRunId` for identity
+
+### 7.3 Human-only guarantee
+
+UI should assume evidence items are strings and:
+- truncate long values
+- avoid rendering nested objects
+- never render raw JSON blobs in normal surfaces
+
+## 8) Agent Narration Plan (#29)
+
+Objective: assistant completion messages should not compete with the receipt card.
+
+Behavior (terminal outcomes):
+- 1-2 lines max.
+- no tables
+- no JSON
+- explicit pointer: Receipt below.
+- PARTIAL/FAILED: include the next safe step in one sentence when available.
+
+Implementation levers:
+- System prompt guidance (see `docs/assistant/system-prompt.md` and `apps/api/src/noa_api/core/prompts/noa-system-prompt.md`).
+- Backend deny-path message (because the agent does not rerun on deny).
+
+## 9) Testing / Verification
+
+API:
+- Unit tests for workflow template payload builders at terminal phases (completed/failed/denied).
+- Integration tests that:
+  - exactly one receipt is persisted per action
+  - exactly one `workflow_receipt` tool-call part is emitted at terminal
+  - deny path emits receipt even without tool run
+
+Web:
+- Component tests for receipt card rendering:
+  - status badge mapping
+  - truncation and max-row rules
+  - "Details" shows full evidence sections
+  - "Copy receipt" output stays human-readable (no JSON)
+
+Manual (end-to-end):
+- WHM happy-path, denied, forced-failure; confirm:
+  - one receipt card per terminal action
+  - assistant completion text is short and non-duplicative
+  - the card fits in one mobile screenshot
+
+## 10) Rollout / Sequencing
+
+Suggested sequence to minimize risk:
+1) Finalize receipt spec and deterministic contract (this document + #26).
+2) Backend persistence + terminal emission (DB migration + #27).
+3) Web receipt UI (new tool UI + #28).
+4) Agent narration standardization (prompt + backend deny-path copy + #29).
+5) Optional backfill for historical terminal actions.
+
+## 11) Open Questions / Decisions
+
+- Persistence location: new `action_receipts` table vs embedding inside `tool_runs.result`.
+- Transport: separate `workflow_receipt` tool-call message vs extending `update_workflow_todo`.
+- Evidence section typing on the web: keep ignoring `key`, or extend UI types to retain it for deterministic filtering.
+- Backfill: do we want old threads to show receipts, or only new actions?
+- Scope expansion: after WHM families, should non-workflow CHANGE tools also emit receipts (same spec)?
+
+## 12) Issue-to-Deliverable Mapping
+
+- #26: final receipt UX + data contract + truncation/ordering rules; confirm no JSON in normal flow.
+- #27: API builds + persists terminal receipt payload and binds it to actionRequest/toolRun.
+- #28: Web renders deterministic receipt card and integrates with detail sheet.
+- #29: Agent completion narration is short, consistent, and always defers to the receipt card.


### PR DESCRIPTION
## What
Add deterministic, screenshot-friendly receipts for workflow-backed ToolRisk.CHANGE actions.

## Why
Terminal CHANGE outcomes were inconsistent and often required reading verbose narration or raw evidence; receipts make the outcome + verification scannable and reliably UI-rendered.

## Changes
- API: persist terminal receipt payload in `action_receipts` (alembic 0006) and emit `workflow_receipt` tool-call + tool-result on completed/failed/denied workflow CHANGE
- Web: render `workflow_receipt` as a compact receipt card (Details sheet + Copy receipt) and register it in the assistant workspace
- Prompt: when a receipt card exists, keep completion narration to 1-2 lines and defer details to the receipt
- UI polish: align success/failed/denied badge colors with the dark Claude-like palette (tint + ring, not light pills)

## Verification
- API: `python3 -m compileall -q apps/api/src/noa_api`
- Web: `npm run typecheck`

Closes #26
Closes #27
Closes #28
Closes #29