### PR TITLE
docs: add FORMAT.md for SPEC.md encoding rules

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -1,0 +1,119 @@
+# SPEC.md FORMAT
+
+Single file. Project root. Every cavekit command reads it.
+
+## SECTIONS
+
+Fixed order. Fixed headers. Addressable.
+
+```
+# SPEC
+
+## §G GOAL
+one line. what code must do.
+
+## §C CONSTRAINTS
+- bullet. non-negotiable boundary.
+- bullet. tech/lang/lib locked in.
+
+## §I INTERFACES
+external surface. what world sees.
+- cmd: `foo bar` → stdout JSON
+- api: POST /x → 200 {id}
+- file: `config.yaml` schema …
+- env: `FOO_KEY` required
+
+## §V INVARIANTS
+numbered. testable. each ! MUST hold.
+V1: ∀ req → auth check before handler
+V2: token expiry ≤ ⊥ allowed
+V3: DB write ! in transaction
+
+## §T TASKS
+pipe table. ids monotonic (never reused). status: `x` done / `~` wip / `.` todo.
+id|status|task|cites
+T1|.|scaffold repo|-
+T2|.|impl §I.api POST /x|V2
+T3|x|add §V.1 middleware|V1,I.api
+
+## §B BUGS
+pipe table. backprop log. each row = bug + invariant that catches recurrence.
+id|date|cause|fix
+B1|2026-04-20|token `<` not `≤`|V2
+B2|2026-04-21|race on write|V3
+```
+
+**Table cell rules**: literal `|` → escape as `\|`. Backticks OK. Cells trimmed. Empty = `-`.
+
+## ADDRESSING
+
+`§<S>.<n>` = section.item. `§V.2` = invariants section, item 2.
+Commands, commits, PRs all reference by §. Zero ambiguity.
+
+## CAVEMAN ENCODING
+
+Default for every section. Rules:
+
+- Drop articles (a, an, the). Drop filler.
+- Drop aux verbs (is, are, was) where fragment works.
+- Short synonyms (fix > implement).
+- Fragments fine.
+
+**Preserve verbatim**: code, paths, identifiers, URLs, numbers, error strings, SQL, regex.
+
+**Symbols** (save tokens, machine-readable):
+
+```
+→   leads to / becomes / triggers
+∴   therefore / fix
+∀   for all / every
+∃   exists / some
+!   must
+?   may / optional
+⊥   never / impossible / forbidden
+≠   not equal / differs from
+∈   in / member of
+∉   not in
+≤   at most
+≥   at least
+&   and
+|   or
+```
+
+**Bad** (v1 prose):
+
+> The authentication middleware must verify the token expiry on every request before allowing the handler to execute.
+
+**Good** (v2 caveman):
+
+> V1: ∀ req → auth check before handler
+
+**Bad** (prose bug note):
+
+> Fixed a bug where token expiry comparison used strict less-than instead of less-than-or-equal, causing tokens to be rejected exactly at their expiry timestamp.
+
+**Good** (v2 caveman):
+
+> B1: token `<` not `<=` ∴ tokens rejected @ expiry. §V.2 now ! `≤`.
+
+## WHY CAVEMAN FOR SPECS
+
+Spec loaded every invocation. 75% fewer tokens = 75% fewer dollars & faster reads.
+Human skims fast too. Symbols unambiguous.
+
+## ONE FILE RULE
+
+Big project → more sections, not more files. grep ceremony kills agent speed.
+If SPEC.md > 500 lines, compact §B (old bugs drop oldest) before splitting.
+
+## WRITES
+
+| command | writes | section |
+|---|---|---|
+| `/spec new` | creates | all |
+| `/spec amend` | edits | chosen |
+| `/spec bug` | appends | §B + §V |
+| `/build` | flips | §T status cell `.` → `~` → `x` |
+| `/check` | — | read only |
+
+That is whole format.


### PR DESCRIPTION
### **User description**
## Summary
- Add `FORMAT.md` defining the caveman-encoded spec format used by cavekit commands
- Covers: section structure (`§G`, `§C`, `§I`, `§V`, `§T`, `§B`), addressing scheme (`§<S>.<n>`), pipe-table rules, symbol reference, and encoding guidelines
- Enables token-efficient specs (~75% fewer tokens vs prose)

## Test plan
- [ ] Verify FORMAT.md renders correctly on GitHub
- [ ] Confirm no conflicts with existing docs


___

### **PR Type**
Documentation


___

### **Description**
- Add FORMAT.md defining caveman-encoded spec format

- Document section structure, addressing scheme, and symbols

- Define pipe-table rules and encoding guidelines

- Explain token-efficient spec rationale (~75% savings)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FORMAT["FORMAT.md"]
  SECTIONS["Section definitions\n§G §C §I §V §T §B"]
  ADDRESSING["Addressing scheme\n§S.n"]
  ENCODING["Caveman encoding\nrules & symbols"]
  COMMANDS["Command write rules\n/spec, /build, /check"]
  FORMAT -- "defines" --> SECTIONS
  FORMAT -- "defines" --> ADDRESSING
  FORMAT -- "defines" --> ENCODING
  FORMAT -- "defines" --> COMMANDS
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FORMAT.md</strong><dd><code>Define caveman-encoded spec format documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

FORMAT.md

<ul><li>Defines the full SPEC.md format with six fixed sections: <code>§G</code> (Goal), <code>§C</code> <br>(Constraints), <code>§I</code> (Interfaces), <code>§V</code> (Invariants), <code>§T</code> (Tasks), <code>§B</code> (Bugs)<br> <li> Documents the <code>§<S>.<n></code> addressing scheme for unambiguous cross-referencing<br> <li> Specifies caveman encoding rules (drop articles/filler, use symbols <br>like <code>→</code>, <code>∀</code>, <code>!</code>, <code>⊥</code>) with good/bad examples<br> <li> Defines pipe-table rules, command write permissions, and the one-file <br>rule for keeping specs compact</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/noa/pull/40/files#diff-3869e7afb262d3246d5fb06d07a83b365705c8e00293ca6e0db8c2e8c888fb0e">+119/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

