### PR TITLE
fix(whm): restrict all firewall CHANGE tools to IPv4-only targets

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -169,6 +169,10 @@ NOA: operational assistant for hosting infrastructure. Monorepo (FastAPI backend
 - V41. `update_workflow_todo`: only one item `in_progress` at a time. Invalid status rejected with valid status list. `waiting_on_user` and `waiting_on_approval` are valid blocked statuses. Empty list clears thread state.
 - V42. 7 registered workflow families: 4 WHM (`whm-account-lifecycle`, `whm-account-contact-email`, `whm-account-primary-domain`, `whm-firewall-batch-change`) + 3 Proxmox (`proxmox-vm-cloudinit-password-reset`, `proxmox-pool-membership-move`, `proxmox-vm-nic-connectivity`).
 
+### Firewall
+
+- V68. ∀ WHM firewall CHANGE tools (`whm_firewall_unblock`, `whm_firewall_allowlist_add_ttl`, `whm_firewall_allowlist_remove`, `whm_firewall_denylist_add_ttl`) ! reject non-IPv4 targets (CIDR, IPv6, hostname). `whm_preflight_firewall_entries` (READ) may accept all types for inspection.
+
 ### Agent
 
 - V43. Multi-round tool-calling loop: max 6 rounds, max 8 tool calls per turn. Temperature 0, tool_choice "auto".
@@ -247,6 +251,7 @@ NOA: operational assistant for hosting infrastructure. Monorepo (FastAPI backend
 | T32 | x | Create `.github/workflows/web-ci.yml` — trigger on `apps/web/**`, Node 20, install, lint, typecheck, test | V65,C13 |
 | T33 | x | Enhance `.github/workflows/api-scaffold-verify.yml` — add ruff lint step before pytest | V66,C13 |
 | T34 | x | Update `README.md` — add badges (CI status), contributing link, code of conduct link, security link, license placeholder | V62 |
+| T35 | x | Restrict `whm_firewall_unblock` & `whm_firewall_allowlist_remove` to IPv4-only targets; reject CIDR/IPv6/hostname same as `_add_ttl` tools. Update `docs/integrations/whm.md:199` to match | V68 |
 
 ## §B Bugs
 
@@ -257,3 +262,4 @@ NOA: operational assistant for hosting infrastructure. Monorepo (FastAPI backend
 | B3 | 2026-04-24 | `_normalize_cors_origins` splits on comma but doesn't handle JSON array format; env `API_CORS_ALLOWED_ORIGINS=["http://localhost:3000"]` produces `['["http://localhost:3000"]']` with brackets in URL; violates C9 | V57,T22 |
 | B4 | 2026-04-24 | `authorization_service.delete_user:187-188` raises `SelfDeleteAdminError("Admins cannot delete their own account")` before checking `is_admin_user`; non-admin self-delete gets misleading admin error | V58,T23 |
 | B5 | 2026-04-24 | `AssistantService` methods use `getattr(self._repository, "method_name", None)` → typo in method name silently returns `None` instead of raising; no type safety on repository/runner | V51,T13 |
+| B6 | 2026-04-26 | `whm_firewall_unblock` & `whm_firewall_allowlist_remove` accept CIDR/IPv6/hostname targets; `_add_ttl` tools correctly reject non-IPv4. Doc `whm.md:199` says "IPv4 only" for all ops but code only enforces on add. Drift both directions: doc imprecise, code too permissive | V68,T35 |

--- a/apps/api/src/noa_api/whm/tools/firewall_tools/__init__.py
+++ b/apps/api/src/noa_api/whm/tools/firewall_tools/__init__.py
@@ -226,6 +226,21 @@ async def whm_firewall_unblock(
             )
             continue
 
+        # Validate IPv4 only for mutation operations
+        parsed_target = parse_csf_target(target)
+        if parsed_target.kind != "ip":
+            overall_ok = False
+            results.append(
+                {
+                    "target": target,
+                    "ok": False,
+                    "status": "error",
+                    "error_code": "invalid_target",
+                    "message": "Firewall unblock only supports IPv4 addresses",
+                }
+            )
+            continue
+
         # Preflight check
         preflight_tasks: dict[str, Any] = {}
         if available["csf"]:
@@ -587,6 +602,21 @@ async def whm_firewall_allowlist_remove(
                     "status": "error",
                     "error_code": "invalid_target",
                     "message": "Target is required",
+                }
+            )
+            continue
+
+        # Validate IPv4 only for mutation operations
+        parsed_target = parse_csf_target(target)
+        if parsed_target.kind != "ip":
+            overall_ok = False
+            results.append(
+                {
+                    "target": target,
+                    "ok": False,
+                    "status": "error",
+                    "error_code": "invalid_target",
+                    "message": "Allowlist remove only supports IPv4 addresses",
                 }
             )
             continue

--- a/apps/api/tests/test_whm_tools_firewall.py
+++ b/apps/api/tests/test_whm_tools_firewall.py
@@ -341,3 +341,106 @@ async def test_whm_firewall_unblock_auto_adds_failed_auth_suspects(monkeypatch) 
     assert captured["server_ref"] == "web1"
     assert captured["lfd_log_line"] == lfd_line
     assert captured["include_raw_output"] is False
+
+
+# ---------------------------------------------------------------------------
+# §V.68 — all firewall CHANGE tools reject non-IPv4 targets
+# ---------------------------------------------------------------------------
+
+_NON_IPV4_TARGETS = [
+    ("192.168.1.0/24", "cidr"),
+    ("2001:db8::1", "ipv6"),
+    ("2001:db8::/32", "ipv6 cidr"),
+    ("mail.example.com", "hostname"),
+]
+
+
+def _setup_resolve_and_binaries(monkeypatch, firewall_tools, server):
+    """Wire up monkeypatches shared by all non-IPv4 rejection tests."""
+    monkeypatch.setattr(
+        firewall_tools, "SQLWHMServerRepository", lambda session: object()
+    )
+
+    async def _resolve(server_ref: str, *, repo) -> SimpleNamespace:
+        _ = server_ref, repo
+        return SimpleNamespace(ok=True, server=server, server_id=server.id)
+
+    async def _check_firewall_binaries(server_obj) -> dict[str, bool]:
+        _ = server_obj
+        return {"csf": True, "imunify": True}
+
+    async def _should_not_run(*args, **kwargs):
+        raise AssertionError("firewall commands should not run for non-IPv4 targets")
+
+    monkeypatch.setattr(firewall_tools, "resolve_whm_server_ref", _resolve)
+    monkeypatch.setattr(
+        firewall_tools, "check_firewall_binaries", _check_firewall_binaries
+    )
+    monkeypatch.setattr(firewall_tools, "run_csf_command", _should_not_run)
+    monkeypatch.setattr(firewall_tools, "run_imunify_command", _should_not_run)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target,kind", _NON_IPV4_TARGETS)
+async def test_whm_firewall_unblock_rejects_non_ipv4(
+    monkeypatch, target: str, kind: str
+) -> None:
+    from noa_api.whm.tools import firewall_tools
+
+    server = _Server(
+        id=uuid4(),
+        name="web1",
+        base_url="https://whm.example.com:2087",
+        api_username="root",
+        api_token="SECRET",
+        verify_ssl=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    _setup_resolve_and_binaries(monkeypatch, firewall_tools, server)
+
+    result = await firewall_tools.whm_firewall_unblock(
+        session=object(),
+        server_ref="web1",
+        targets=[target],
+        reason="test",
+    )
+
+    assert result["ok"] is False
+    entry = result["results"][0]
+    assert entry["ok"] is False
+    assert entry["error_code"] == "invalid_target"
+    assert "IPv4" in entry["message"], f"expected IPv4 mention for {kind} target"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target,kind", _NON_IPV4_TARGETS)
+async def test_whm_firewall_allowlist_remove_rejects_non_ipv4(
+    monkeypatch, target: str, kind: str
+) -> None:
+    from noa_api.whm.tools import firewall_tools
+
+    server = _Server(
+        id=uuid4(),
+        name="web1",
+        base_url="https://whm.example.com:2087",
+        api_username="root",
+        api_token="SECRET",
+        verify_ssl=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    _setup_resolve_and_binaries(monkeypatch, firewall_tools, server)
+
+    result = await firewall_tools.whm_firewall_allowlist_remove(
+        session=object(),
+        server_ref="web1",
+        targets=[target],
+        reason="test",
+    )
+
+    assert result["ok"] is False
+    entry = result["results"][0]
+    assert entry["ok"] is False
+    assert entry["error_code"] == "invalid_target"
+    assert "IPv4" in entry["message"], f"expected IPv4 mention for {kind} target"

--- a/docs/integrations/whm.md
+++ b/docs/integrations/whm.md
@@ -196,7 +196,7 @@ Tool definitions: `apps/api/src/noa_api/core/tools/definitions/whm.py`
 - Primary domain change (with DNS zone postflight verification)
 - Domain owner lookup (internal helper for primary-domain preflight, not a standalone tool)
 - Domain list lookup via WHM UAPI bridge (internal helper, not a standalone tool)
-- Firewall/IP operations via SSH using CSF and Imunify360 (IPv4 only; no CIDR, hostname, or IPv6)
+- Firewall/IP operations via SSH using CSF and Imunify360 (all CHANGE tools IPv4 only; preflight accepts IPv4, IPv6, CIDR, and hostnames for inspection)
 - Binary existence checks over SSH
 - Mail log failed-auth username suspect analysis over SSH
 


### PR DESCRIPTION
### **User description**
## Summary

All WHM firewall CHANGE tools now reject non-IPv4 targets (CIDR, IPv6, hostname). Previously `whm_firewall_unblock` and `whm_firewall_allowlist_remove` accepted all target types while `_add_ttl` tools correctly restricted to IPv4. This was a doc-vs-code drift discovered during integration docs audit.

## Changes

- Add IPv4 validation guard to `whm_firewall_unblock` (rejects CIDR/IPv6/hostname with `invalid_target` error)
- Add IPv4 validation guard to `whm_firewall_allowlist_remove` (same pattern)
- Update `docs/integrations/whm.md` line 199 to accurately describe the restriction
- Add `§V.68` invariant, `§B.6` bug entry, mark `§T.35` complete in SPEC.md
- Add 8 parametrized tests (4 target types x 2 tools) verifying non-IPv4 rejection

## Testing

- [x] Unit tests pass (`uv run pytest -q` — 732 passed)
- [x] Linting passes (`uv run ruff check src tests`)
- [x] New tests cover all non-IPv4 target types: CIDR, IPv6, IPv6 CIDR, hostname
- [x] Existing firewall tests still pass (no regression)

### Manual Testing Steps

1. Call `whm_firewall_unblock` with a CIDR target → should return `invalid_target` error
2. Call `whm_firewall_allowlist_remove` with an IPv6 target → should return `invalid_target` error
3. Call either tool with a plain IPv4 → should work as before

## Security Checklist

- [x] No secrets or credentials committed
- [x] No auth bypass introduced
- [x] No weakening of input sanitization (this tightens it)
- [x] No raw SQL

## Related Issues

Closes #41


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Add IPv4-only validation to `whm_firewall_unblock` and `whm_firewall_allowlist_remove`

- Reject CIDR, IPv6, and hostname targets with `invalid_target` error

- Add 8 parametrized tests covering all non-IPv4 target types

- Update docs and SPEC to reflect consistent IPv4-only enforcement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Input["Non-IPv4 target (CIDR/IPv6/hostname)"]
  Parse["parse_csf_target()"]
  Check{"kind == 'ip'?"}
  Reject["Return invalid_target error"]
  Proceed["Execute firewall command"]
  Input --> Parse --> Check
  Check -- "No" --> Reject
  Check -- "Yes" --> Proceed
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add IPv4-only validation to unblock and allowlist remove</code>&nbsp; </dd></summary>
<hr>

apps/api/src/noa_api/whm/tools/firewall_tools/__init__.py

<ul><li>Add <code>parse_csf_target()</code> validation guard in <code>whm_firewall_unblock</code> to <br>reject non-IPv4 targets before executing firewall commands<br> <li> Add identical <code>parse_csf_target()</code> validation guard in <br><code>whm_firewall_allowlist_remove</code><br> <li> Both guards return <code>invalid_target</code> error with descriptive IPv4-only <br>message and set <code>overall_ok = False</code></ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/noa/pull/42/files#diff-a85008aefce4989ae29c342bb7d8039971afe2c7d7a48c9ab7af0f0e31303c09">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_whm_tools_firewall.py</strong><dd><code>Parametrized tests for non-IPv4 target rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/tests/test_whm_tools_firewall.py

<ul><li>Add <code>_NON_IPV4_TARGETS</code> parametrized list covering CIDR, IPv6, IPv6 <br>CIDR, and hostname<br> <li> Add shared <code>_setup_resolve_and_binaries</code> helper that monkeypatches <br>dependencies and asserts firewall commands never run<br> <li> Add <code>test_whm_firewall_unblock_rejects_non_ipv4</code> with 4 parametrized <br>cases<br> <li> Add <code>test_whm_firewall_allowlist_remove_rejects_non_ipv4</code> with 4 <br>parametrized cases</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/noa/pull/42/files#diff-4c40a2824ad5c8282853238c39b3be10c3adb31e8c88ff79b9514102dc8329f5">+103/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SPEC.md</strong><dd><code>Add SPEC entries for firewall IPv4 invariant and bug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SPEC.md

<ul><li>Add <code>§V.68</code> invariant documenting IPv4-only enforcement for all firewall <br>CHANGE tools<br> <li> Mark <code>§T.35</code> as complete for restricting unblock/remove to IPv4-only<br> <li> Add <code>§B.6</code> bug entry documenting the doc-vs-code drift for firewall <br>target validation</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/noa/pull/42/files#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>whm.md</strong><dd><code>Clarify IPv4-only scope in integration docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/integrations/whm.md

<ul><li>Update firewall operations description to clarify that CHANGE tools <br>are IPv4-only while preflight accepts all target types</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/noa/pull/42/files#diff-91a1779e3d9ba54af4e1c9247883fdc8d6a61e0eb7e5b31b713f2d8f053036d2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

