### PR TITLE
fix(proxmox): accept @pve realm suffix in email params, relax pool ACL check

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -162,7 +162,9 @@ NOA: operational assistant for hosting infrastructure. Monorepo (FastAPI backend
 
 - V38. WHM CHANGE tools without matching preflight evidence → `FAILED` with `preflight_required`. Matching preflight allows execution. Mismatched account in preflight → blocked.
 - V39. All Proxmox CHANGE tools expose preflight guidance in description. Proxmox CHANGE tools have `workflow_family` metadata.
-- V69. Pool membership move (Change Email PIC) ! require `old_email` + `new_email` (not single `email`). `old_email` ! have permissions on `source_pool`, `new_email` ! have permissions on `destination_pool`. `old_email` ≠ `new_email` (same PIC → `invalid_request`). Cross-validation prevents typo-based customer mismatch. System prompt ! map "change email PIC" / "change PIC" → pool membership move workflow.
+- V69. Pool membership move (Change Email PIC) ! require `old_email` + `new_email` (not single `email`). `old_email` ! exist on `source_pool` ACL, `new_email` ! exist on `destination_pool` ACL. `old_email` ≠ `new_email` (same PIC → `invalid_request`). Cross-validation prevents typo-based customer mismatch. System prompt ! map "change email PIC" / "change PIC" → pool membership move workflow.
+- V70. Proxmox email params (`old_email`, `new_email`, `email`) ! accept both plain email (`user@domain.com`) and Proxmox userid (`user@domain.com@pve`). `_normalize_proxmox_userid` strips/appends realm as needed. Argument validation ! not reject `@pve` realm suffix as invalid email format.
+- V71. Pool membership preflight ! check user **exists on pool ACL** (any role/permission entry), not specific privileges. `PVEConsoleUser`, `PVEVMAdmin`, any custom role — all valid pool association. `_has_any_pool_permission` ! return non-None when user has any ACL entry on pool path, regardless of which permissions granted.
 
 ### Workflows
 
@@ -254,6 +256,8 @@ NOA: operational assistant for hosting infrastructure. Monorepo (FastAPI backend
 | T34 | x | Update `README.md` — add badges (CI status), contributing link, code of conduct link, security link, license placeholder | V62 |
 | T35 | x | Restrict `whm_firewall_unblock` & `whm_firewall_allowlist_remove` to IPv4-only targets; reject CIDR/IPv6/hostname same as `_add_ttl` tools. Update `docs/integrations/whm.md:199` to match | V68 |
 | T36 | x | Reframe pool membership move as "Change Email PIC": replace single `email` → `old_email` + `new_email`; validate both against respective pools; update tool defs, prompt_hints, system prompt, workflow templates, matching, evidence, tests, docs | V69 |
+| T37 | x | Fix Proxmox email param validation: strip `@pve` realm suffix before `_EMAIL_RE` check in `argument_validation.py`, or use custom format for Proxmox email params (not `"email"`). Update preflight error msgs to show normalized userid for clarity | V70,B7 |
+| T38 | x | Fix pool membership preflight: replace `_REQUIRED_POOL_PERMISSIONS` intersection check with any-ACL-entry check. `_has_any_pool_permission` ! return non-None when user has any permission entry on pool path (any role counts as pool association). Update tests | V71,B8 |
 
 ## §B Bugs
 
@@ -265,3 +269,5 @@ NOA: operational assistant for hosting infrastructure. Monorepo (FastAPI backend
 | B4 | 2026-04-24 | `authorization_service.delete_user:187-188` raises `SelfDeleteAdminError("Admins cannot delete their own account")` before checking `is_admin_user`; non-admin self-delete gets misleading admin error | V58,T23 |
 | B5 | 2026-04-24 | `AssistantService` methods use `getattr(self._repository, "method_name", None)` → typo in method name silently returns `None` instead of raising; no type safety on repository/runner | V51,T13 |
 | B6 | 2026-04-26 | `whm_firewall_unblock` & `whm_firewall_allowlist_remove` accept CIDR/IPv6/hostname targets; `_add_ttl` tools correctly reject non-IPv4. Doc `whm.md:199` says "IPv4 only" for all ops but code only enforces on add. Drift both directions: doc imprecise, code too permissive | V68,T35 |
+| B7 | 2026-04-26 | `_EMAIL_RE` (`^[^@\s]+@[^@\s]+\.[^@\s]+$`) in `argument_validation.py:10` rejects Proxmox userids containing `@pve` realm suffix (two `@` symbols). LM sees `user@domain.com@pve` in Proxmox data, echoes it back → argument validation blocks tool call with "not valid email". Without `@pve` tool works (code appends internally) but LM behavior unpredictable — sometimes includes realm from upstream data | V70,T37 |
+| B8 | 2026-04-26 | `_meaningful_permission_entries` in `pool_tools.py:65` checks intersection with `_REQUIRED_POOL_PERMISSIONS` (`VM.Allocate`, `Pool.Allocate`, `Pool.Audit`). User with `PVEConsoleUser` role (grants `VM.Console`, `VM.PowerMgmt`, etc.) has valid ACL entry on pool but zero overlap with required set → preflight rejects as "does not have permissions". Change PIC only needs to confirm user exists on pool ACL, not specific privileges | V71,T38 |

--- a/apps/api/src/noa_api/core/tools/argument_validation.py
+++ b/apps/api/src/noa_api/core/tools/argument_validation.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_PVE_REALM_SUFFIX = "@pve"
 _SERVER_REF_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
 _WHM_USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
 
@@ -138,6 +139,15 @@ def _validate_string(schema: dict[str, Any], *, value: object, path: str) -> lis
 
     if schema.get("format") == "email" and not _EMAIL_RE.match(normalized):
         problems.append(f"{_format_path(path)} must be a valid email address")
+
+    if schema.get("format") == "proxmox-email":
+        email_part = (
+            normalized[: -len(_PVE_REALM_SUFFIX)]
+            if normalized.endswith(_PVE_REALM_SUFFIX)
+            else normalized
+        )
+        if not _EMAIL_RE.match(email_part):
+            problems.append(f"{_format_path(path)} must be a valid email address")
 
     pattern = schema.get("pattern")
     if isinstance(pattern, str) and not re.fullmatch(pattern, normalized):

--- a/apps/api/src/noa_api/core/tools/schemas/proxmox.py
+++ b/apps/api/src/noa_api/core/tools/schemas/proxmox.py
@@ -49,18 +49,18 @@ PROXMOX_DIGEST_PARAM = _string_param(
 )
 
 PROXMOX_EMAIL_PARAM = _string_param(
-    "Exact email address used to identify the Proxmox user account.",
-    format_name="email",
+    "Email address or Proxmox userid (e.g. user@domain.com or user@domain.com@pve) to identify the Proxmox user account.",
+    format_name="proxmox-email",
 )
 
 PROXMOX_OLD_EMAIL_PARAM = _string_param(
-    "Exact email address of the current (old) PIC who owns the source pool.",
-    format_name="email",
+    "Email address or Proxmox userid of the current (old) PIC who owns the source pool.",
+    format_name="proxmox-email",
 )
 
 PROXMOX_NEW_EMAIL_PARAM = _string_param(
-    "Exact email address of the new PIC who owns the destination pool.",
-    format_name="email",
+    "Email address or Proxmox userid of the new PIC who owns the destination pool.",
+    format_name="proxmox-email",
 )
 
 PROXMOX_POOL_PARAM = _string_param(

--- a/apps/api/src/noa_api/proxmox/tools/pool_tools.py
+++ b/apps/api/src/noa_api/proxmox/tools/pool_tools.py
@@ -59,20 +59,23 @@ def _validated_pool_vmids(result: dict[str, object]) -> set[int] | None:
         return None
 
 
-_REQUIRED_POOL_PERMISSIONS = {"VM.Allocate", "Pool.Allocate", "Pool.Audit"}
-
-
-def _meaningful_permission_entries(
+def _has_any_pool_permission(
     result: dict[str, object], path: str
 ) -> dict[str, object] | None:
+    """Return permission entries if user has *any* ACL entry on *path*.
+
+    Change-PIC preflight only needs to confirm the user exists on the pool
+    ACL — any role (``PVEConsoleUser``, ``PVEVMAdmin``, custom, …) counts
+    as valid pool association.  See §V.71.
+    """
     data = result.get("data")
     if not isinstance(data, dict):
         return None
     permissions = data.get(path)
     if not isinstance(permissions, dict) or not permissions:
         return None
-    granted = {key for key, value in permissions.items() if value == 1 or value is True}
-    if not granted.intersection(_REQUIRED_POOL_PERMISSIONS):
+    has_any = any(value == 1 or value is True for value in permissions.values())
+    if not has_any:
         return None
     return permissions
 
@@ -211,7 +214,7 @@ async def proxmox_preflight_move_vms_between_pools(
         )
 
     if (
-        _meaningful_permission_entries(
+        _has_any_pool_permission(
             source_permission_result, f"/pool/{normalized_source_pool}"
         )
         is None
@@ -219,7 +222,7 @@ async def proxmox_preflight_move_vms_between_pools(
         return {
             "ok": False,
             "error_code": "permission_required",
-            "message": "Old email does not have permissions on the source pool",
+            "message": f"Old email ({normalized_old_userid}) does not have any ACL entry on the source pool",
         }
 
     # Validate new email has permissions on destination pool
@@ -234,7 +237,7 @@ async def proxmox_preflight_move_vms_between_pools(
         )
 
     if (
-        _meaningful_permission_entries(
+        _has_any_pool_permission(
             destination_permission_result, f"/pool/{normalized_destination_pool}"
         )
         is None
@@ -242,7 +245,7 @@ async def proxmox_preflight_move_vms_between_pools(
         return {
             "ok": False,
             "error_code": "permission_required",
-            "message": "New email does not have permissions on the destination pool",
+            "message": f"New email ({normalized_new_userid}) does not have any ACL entry on the destination pool",
         }
 
     if not all(vmid in source_pool_vmids for vmid in vmids):

--- a/apps/api/tests/test_proxmox_tools_pools.py
+++ b/apps/api/tests/test_proxmox_tools_pools.py
@@ -588,7 +588,7 @@ async def test_proxmox_preflight_move_vms_between_pools_rejects_empty_source_per
     assert result == {
         "ok": False,
         "error_code": "permission_required",
-        "message": "Old email does not have permissions on the source pool",
+        "message": "Old email (l1@biznetgio.com@pve) does not have any ACL entry on the source pool",
     }
 
 
@@ -666,7 +666,7 @@ async def test_proxmox_preflight_move_vms_between_pools_rejects_empty_destinatio
     assert result == {
         "ok": False,
         "error_code": "permission_required",
-        "message": "New email does not have permissions on the destination pool",
+        "message": "New email (l2@biznetgio.com@pve) does not have any ACL entry on the destination pool",
     }
 
 
@@ -1477,3 +1477,83 @@ async def test_proxmox_move_vms_between_pools_rejects_malformed_refetch_payload_
         ("get_pool", "pool_a"),
         ("get_pool", "pool_b"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_proxmox_preflight_accepts_pve_console_user_role(
+    monkeypatch,
+) -> None:
+    """V71/B8: PVEConsoleUser has no VM.Allocate/Pool.Allocate/Pool.Audit but
+    is a valid pool ACL entry — preflight must accept it."""
+    from noa_api.proxmox.tools import pool_tools
+
+    server = _server()
+    # PVEConsoleUser grants VM.Console + VM.PowerMgmt, not VM.Allocate
+    source_permission_result = {
+        "ok": True,
+        "message": "ok",
+        "data": {"/pool/pool_a": {"VM.Console": 1, "VM.PowerMgmt": 1}},
+    }
+    destination_permission_result = {
+        "ok": True,
+        "message": "ok",
+        "data": {"/pool/pool_b": {"VM.Console": 1, "VM.PowerMgmt": 1}},
+    }
+
+    class _Client:
+        def __init__(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        async def get_pool(self, poolid: str) -> dict[str, object]:
+            return _pool_payload(
+                poolid, [{"vmid": 1040}] if poolid == "pool_a" else []
+            )
+
+        async def get_user(self, userid: str) -> dict[str, object]:
+            return {
+                "ok": True,
+                "message": "ok",
+                "data": {"userid": userid, "enable": 1},
+            }
+
+        async def get_effective_permissions(
+            self, userid: str, path: str
+        ) -> dict[str, object]:
+            return {
+                ("l1@biznetgio.com@pve", "/pool/pool_a"): source_permission_result,
+                ("l2@biznetgio.com@pve", "/pool/pool_b"): destination_permission_result,
+            }[(userid, path)]
+
+        async def add_vms_to_pool(
+            self, poolid: str, vmids: list[int]
+        ) -> dict[str, object]:
+            return {"ok": True, "message": "ok", "data": None}
+
+        async def remove_vms_from_pool(
+            self, poolid: str, vmids: list[int]
+        ) -> dict[str, object]:
+            return {"ok": True, "message": "ok", "data": None}
+
+    from noa_api.proxmox.tools import _shared
+
+    monkeypatch.setattr(_shared, "ProxmoxClient", _Client)
+    monkeypatch.setattr(pool_tools, "ProxmoxClient", _Client)
+    monkeypatch.setattr(
+        pool_tools,
+        "SQLProxmoxServerRepository",
+        lambda session: _Repo([server]),
+    )
+
+    result = await pool_tools.proxmox_preflight_move_vms_between_pools(
+        session=_Session(),
+        server_ref="pve1",
+        source_pool="pool_a",
+        destination_pool="pool_b",
+        vmids=[1040],
+        old_email="l1@biznetgio.com",
+        new_email="l2@biznetgio.com",
+    )
+
+    assert result["ok"] is True
+    assert result["source_permission"] is source_permission_result
+    assert result["destination_permission"] is destination_permission_result

--- a/apps/api/tests/test_tool_argument_validation.py
+++ b/apps/api/tests/test_tool_argument_validation.py
@@ -278,3 +278,89 @@ def test_validate_tool_arguments_rejects_non_positive_pool_move_vmids(
         "error_code": "invalid_tool_arguments",
         "details": ["vmids[0] must be greater than or equal to 1"],
     }
+
+
+def test_validate_tool_arguments_accepts_proxmox_email_with_pve_realm() -> None:
+    """V70: Proxmox email params accept ``user@domain.com@pve`` userid format."""
+    tool = get_tool_definition("proxmox_get_user_by_email")
+
+    assert tool is not None
+
+    # Should not raise — @pve suffix is valid for Proxmox emails
+    validate_tool_arguments(
+        tool=tool,
+        args={"server_ref": "pve1", "email": "l1@biznetgio.com@pve"},
+    )
+
+
+def test_validate_tool_arguments_accepts_proxmox_email_without_pve_realm() -> None:
+    """V70: Proxmox email params also accept plain email without @pve."""
+    tool = get_tool_definition("proxmox_get_user_by_email")
+
+    assert tool is not None
+
+    validate_tool_arguments(
+        tool=tool,
+        args={"server_ref": "pve1", "email": "l1@biznetgio.com"},
+    )
+
+
+def test_validate_tool_arguments_rejects_invalid_proxmox_email() -> None:
+    """V70: Proxmox email params still reject truly invalid emails."""
+    tool = get_tool_definition("proxmox_get_user_by_email")
+
+    assert tool is not None
+
+    with pytest.raises(ToolArgumentValidationError) as exc_info:
+        validate_tool_arguments(
+            tool=tool,
+            args={"server_ref": "pve1", "email": "not-an-email"},
+        )
+
+    assert "email must be a valid email address" in exc_info.value.as_result()["details"]
+
+
+def test_validate_tool_arguments_accepts_pool_move_emails_with_pve_realm() -> None:
+    """V70: old_email and new_email accept @pve suffix in pool move."""
+    tool = get_tool_definition("proxmox_preflight_move_vms_between_pools")
+
+    assert tool is not None
+
+    validate_tool_arguments(
+        tool=tool,
+        args={
+            "server_ref": "pve1",
+            "source_pool": "pool_a",
+            "destination_pool": "pool_b",
+            "vmids": [1040],
+            "old_email": "l1@biznetgio.com@pve",
+            "new_email": "l2@biznetgio.com@pve",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "@pve",
+        "@@pve",
+        "user@@pve",
+        "not-an-email@pve",
+    ],
+)
+def test_validate_tool_arguments_rejects_proxmox_email_edge_cases(
+    email: str,
+) -> None:
+    """V70: @pve suffix stripping must still reject malformed underlying email."""
+    tool = get_tool_definition("proxmox_get_user_by_email")
+
+    assert tool is not None
+
+    with pytest.raises(ToolArgumentValidationError) as exc_info:
+        validate_tool_arguments(
+            tool=tool,
+            args={"server_ref": "pve1", "email": email},
+        )
+
+    details = exc_info.value.as_result()["details"]
+    assert any("email must be" in d for d in details)

--- a/apps/api/tests/test_tools_registry.py
+++ b/apps/api/tests/test_tools_registry.py
@@ -71,7 +71,7 @@ async def test_tool_registry_exposes_machine_readable_parameter_schemas() -> Non
     assert by_name["proxmox_disable_vm_nic"].result_schema is not None
 
     proxmox_user_schema = by_name["proxmox_get_user_by_email"].parameters_schema
-    assert proxmox_user_schema["properties"]["email"]["format"] == "email"
+    assert proxmox_user_schema["properties"]["email"]["format"] == "proxmox-email"
 
     proxmox_move_schema = by_name["proxmox_move_vms_between_pools"].parameters_schema
     assert proxmox_move_schema["required"] == [

--- a/docs/integrations/proxmox.md
+++ b/docs/integrations/proxmox.md
@@ -253,8 +253,8 @@ Important:
 - Do not mutate Proxmox user email fields.
 - Do not add or remove ACL entries as part of this flow.
 - Ask the user directly for the source pool, destination pool, one or more VMIDs, the old email (current PIC who owns the source pool), and the new email (new PIC who owns the destination pool).
-- Both emails are validated against their respective pools: `old_email` must have permissions on `source_pool`, `new_email` must have permissions on `destination_pool`. This cross-validation prevents typo-based customer mismatch.
-- Do not pass an already-suffixed Proxmox userid here; the implementation conditionally appends `@pve` (if input already ends with `@pve`, it is returned unchanged).
+- Both emails are validated against their respective pools: `old_email` must exist on `source_pool` ACL, `new_email` must exist on `destination_pool` ACL (any role counts — `PVEConsoleUser`, `PVEVMAdmin`, custom roles all valid). This cross-validation prevents typo-based customer mismatch.
+- Accepts both plain email (`user@domain.com`) and Proxmox userid (`user@domain.com@pve`). The implementation conditionally appends `@pve` (if input already ends with `@pve`, it is returned unchanged).
 - The user should NOT be asked for "the email of the user performing the move." Instead, ask for old email (current owner) and new email (new owner).
 
 ### Read one user by email-derived userid


### PR DESCRIPTION
### **User description**
## Summary

- Fix email validation rejecting Proxmox userids with `@pve` realm suffix (B7)
- Fix pool membership preflight requiring specific permissions instead of any ACL entry (B8)

Closes #45

## Changes

### B7 — `proxmox-email` format (§V.70, §T.37)
- Add `proxmox-email` format in `argument_validation.py` that strips `@pve` suffix before applying `_EMAIL_RE`
- Switch 3 Proxmox email param schemas (`email`, `old_email`, `new_email`) from `"email"` → `"proxmox-email"`
- Update schema descriptions to tell LM both plain email and `@pve` userid accepted

### B8 — Any-ACL-entry check (§V.71, §T.38)
- Replace `_REQUIRED_POOL_PERMISSIONS` intersection check with `_has_any_pool_permission` — any role (`PVEConsoleUser`, `PVEVMAdmin`, custom) counts as valid pool association
- Error messages now include normalized userid for operator clarity

### Docs & spec
- Update `docs/integrations/proxmox.md` pool membership section to match new behavior
- Add §V.70, §V.71, §B.7, §B.8, §T.37(x), §T.38(x) to SPEC.md

## Testing

- [x] `uv run ruff check src tests` — clean
- [x] `uv run pytest -q` — 743 passed
- [x] New tests: `@pve` accepted, plain email accepted, invalid rejected, edge cases (`@pve` alone, `@@pve`, `user@@pve`), `PVEConsoleUser` role accepted in preflight
- [ ] Manual: Change Email PIC workflow with `PVEConsoleUser` user on real Proxmox

## Security

- [x] No secrets or credentials committed
- [x] No auth bypass introduced
- [x] No raw SQL
- [x] Validation relaxation is scoped to Proxmox email params only; WHM email stays strict


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Add `proxmox-email` format accepting `@pve` realm suffix

- Relax pool ACL check to accept any role

- Add tests for `@pve` email and `PVEConsoleUser` role

- Update SPEC.md and docs with new behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LM sends user@domain.com@pve"] -- "proxmox-email format" --> B["Strip @pve suffix"]
  B -- "_EMAIL_RE validation" --> C["Valid email accepted"]
  D["User has PVEConsoleUser role"] -- "any ACL entry check" --> E["Pool association confirmed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>argument_validation.py</strong><dd><code>Add proxmox-email format stripping @pve before validation</code></dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-2bd75bb636b772f183481ca520c5117005cf1a83addca2151e05aaec548ba08d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proxmox.py</strong><dd><code>Switch Proxmox email params to proxmox-email format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-7b157132735e5da668ced4236acf0eac99b7999e68825b86cf29d84cd049a39b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pool_tools.py</strong><dd><code>Replace specific permission check with any-ACL-entry check</code></dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-c7c72b0ad9fcd1b055002324fa56c45ead1a4d6d5d048bc6b58fb864a5fc11ae">+13/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_proxmox_tools_pools.py</strong><dd><code>Update error messages and add PVEConsoleUser acceptance test</code></dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-5cc17e4e80f96515b819593f1a2002b68de1f83766e93e1b8b02d40bf85688f6">+82/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tool_argument_validation.py</strong><dd><code>Add tests for proxmox-email format and edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-0a18a0160c0d14d7c3cd0daebb3f268cb02792710c072467308879036ac81ee5">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tools_registry.py</strong><dd><code>Update schema assertion to proxmox-email format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-504b5b3eeb9af4a7b4b8045a7bf1819441214c7f284861a7ea60b6685456e430">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>SPEC.md</strong><dd><code>Add V70, V71, B7, B8, T37, T38 spec entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proxmox.md</strong><dd><code>Update pool membership docs for relaxed ACL check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rendyuwu/noa/pull/46/files#diff-fb618bb5b81492be17ffd749b6f3da1a07f0a060db5ceace5b5c46bb68d3b30a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

